### PR TITLE
SVG : Use event_handler for svg events instead of strings.

### DIFF
--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -807,43 +807,48 @@ module Make(Xml : Xml_sigs.T) = struct
 
   let a_name = string_attrib "name"
 
-  let a_name = user_attrib string_of_string "name"
+  let a_onabort = Xml.event_handler_attrib "onabort"
 
-  let a_onabort = user_attrib string_of_string "onabort"
+  let a_onactivate = Xml.event_handler_attrib "onactivate"
 
-  let a_onactivate = user_attrib string_of_string "onactivate"
+  let a_onbegin = Xml.event_handler_attrib "onbegin"
 
-  let a_onbegin = user_attrib string_of_string "onbegin"
+  let a_onclick = Xml.event_handler_attrib "onclick"
 
-  let a_onclick = user_attrib string_of_string "onclick"
+  let a_onend = Xml.event_handler_attrib "onend"
 
-  let a_onend = user_attrib string_of_string "onend"
+  let a_onerror = Xml.event_handler_attrib "onerror"
 
-  let a_onerror = user_attrib string_of_string "onerror"
+  let a_onfocusin = Xml.event_handler_attrib "onfocusin"
 
-  let a_onfocusin = user_attrib string_of_string "onfocusin"
+  let a_onfocusout = Xml.event_handler_attrib "onfocusout"
 
-  let a_onfocusout = user_attrib string_of_string "onfocusout"
+  let a_onload = Xml.event_handler_attrib "onload"
 
-  let a_onload = user_attrib string_of_string "onload"
+  let a_onmousedown = Xml.event_handler_attrib "onmousdown"
 
-  let a_onmousedown = user_attrib string_of_string "onmousdown"
+  let a_onmouseup = Xml.event_handler_attrib "onmouseup"
 
-  let a_onmouseup = user_attrib string_of_string "onmouseup"
+  let a_onmouseover = Xml.event_handler_attrib "onmouseover"
 
-  let a_onmouseover = user_attrib string_of_string "onmouseover"
+  let a_onmouseout = Xml.event_handler_attrib "onmouseout"
 
-  let a_onmouseout = user_attrib string_of_string "onmouseout"
+  let a_onmousemove = Xml.event_handler_attrib "onmousemove"
 
-  let a_onmousemove = user_attrib string_of_string "onmousemove"
+  let a_onrepeat = Xml.event_handler_attrib "onrepeat"
 
-  let a_onrepeat = user_attrib string_of_string "onrepeat"
+  let a_onresize = Xml.event_handler_attrib "onresize"
+
+  let a_onscroll = Xml.event_handler_attrib "onscroll"
+
+  let a_onunload = Xml.event_handler_attrib "onunload"
+
+  let a_onzoom = Xml.event_handler_attrib "onzoom"
+
   let a_stopcolor = user_attrib string_of_color "stop-color"
 
-  let a_onresize = user_attrib string_of_string "onresize"
   let a_stopopacity = user_attrib string_of_number "stop-opacity"
 
-  let a_onscroll = user_attrib string_of_string "onscroll"
   let a_stroke = user_attrib string_of_paint "stroke"
 
   let a_strokewidth = user_attrib string_of_length "stroke-width"
@@ -868,11 +873,9 @@ module Make(Xml : Xml_sigs.T) = struct
         | l -> list string_of_length l
       )
 
-  let a_onunload = user_attrib string_of_string "onunload"
   let a_strokedashoffset =
     user_attrib string_of_length "stroke-dashoffset"
 
-  let a_onzoom = user_attrib string_of_string "onzoom"
   let a_strokeopacity =
     user_attrib string_of_number "stroke-opacity"
 

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -523,43 +523,43 @@ module type T = sig
 
   val a_name : string -> [> | `Name ] attrib
 
-  val a_onabort : string -> [> | `Onabort ] attrib
+  val a_onabort : Xml.event_handler -> [> | `OnAbort ] attrib
 
-  val a_onactivate : string -> [> | `Onactivate ] attrib
+  val a_onactivate : Xml.event_handler -> [> | `OnActivate ] attrib
 
-  val a_onbegin : string -> [> | `Onbegin ] attrib
+  val a_onbegin : Xml.event_handler -> [> | `OnBegin ] attrib
 
-  val a_onclick : string -> [> | `Onclick ] attrib
+  val a_onclick : Xml.event_handler -> [> | `OnClick ] attrib
 
-  val a_onend : string -> [> | `Onend ] attrib
+  val a_onend : Xml.event_handler -> [> | `OnEnd ] attrib
 
-  val a_onerror : string -> [> | `Onerror ] attrib
+  val a_onerror : Xml.event_handler -> [> | `OnError ] attrib
 
-  val a_onfocusin : string -> [> | `Onfocusin ] attrib
+  val a_onfocusin : Xml.event_handler -> [> | `OnFocusIn ] attrib
 
-  val a_onfocusout : string -> [> | `Onfocusout ] attrib
+  val a_onfocusout : Xml.event_handler -> [> | `OnFocusOut ] attrib
 
-  val a_onload : string -> [> | `Onload ] attrib
+  val a_onload : Xml.event_handler -> [> | `OnLoad ] attrib
 
-  val a_onmousedown : string -> [> | `Onmousdown ] attrib
+  val a_onmousedown : Xml.event_handler -> [> | `OnMouseDown ] attrib
 
-  val a_onmouseup : string -> [> | `Onmouseup ] attrib
+  val a_onmouseup : Xml.event_handler -> [> | `OnMouseUp ] attrib
 
-  val a_onmouseover : string -> [> | `Onmouseover ] attrib
+  val a_onmouseover : Xml.event_handler -> [> | `OnMouseOver ] attrib
 
-  val a_onmouseout : string -> [> | `Onmouseout ] attrib
+  val a_onmouseout : Xml.event_handler -> [> | `OnMouseOut ] attrib
 
-  val a_onmousemove : string -> [> | `Onmousemove ] attrib
+  val a_onmousemove : Xml.event_handler -> [> | `OnMouseMove ] attrib
 
-  val a_onrepeat : string -> [> | `Onrepeat ] attrib
+  val a_onrepeat : Xml.event_handler -> [> | `OnRepeat ] attrib
 
-  val a_onresize : string -> [> | `Onresize ] attrib
+  val a_onresize : Xml.event_handler -> [> | `OnResize ] attrib
 
-  val a_onscroll : string -> [> | `Onscroll ] attrib
+  val a_onscroll : Xml.event_handler -> [> | `OnScroll ] attrib
 
-  val a_onunload : string -> [> | `Onunload ] attrib
+  val a_onunload : Xml.event_handler -> [> | `OnUnload ] attrib
 
-  val a_onzoom : string -> [> | `Onzoom ] attrib
+  val a_onzoom : Xml.event_handler -> [> | `OnZoom ] attrib
 
   val metadata :
     ?a: ((metadata_attr attrib) list) -> Xml.elt list -> [> | metadata] elt


### PR DESCRIPTION
Modified version of gal_bolle's patch. 
Go with [this patch for eliom](https://github.com/ocsigen/eliom/pull/6).
