### PR TITLE
Replace fake boolean by actual booleans.

### DIFF
--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -88,6 +88,8 @@ module MakeWrapped
 
   let event_handler_attrib = Xml.event_handler_attrib
 
+  let bool_attrib = user_attrib string_of_bool
+
   (* Deprecated alias. *)
   let event_attrib = Xml.event_handler_attrib
 
@@ -438,10 +440,7 @@ module MakeWrapped
   let a_challenge = string_attrib "challenge"
 
   let a_contenteditable ce =
-    let f = function
-      | `True -> "true"
-      | `False -> "false"
-    in user_attrib f "contenteditable" ce
+    bool_attrib "contenteditable" ce
 
   let a_contextmenu = string_attrib "contextmenu"
 
@@ -457,10 +456,7 @@ module MakeWrapped
     in user_attrib f "dir" d
 
   let a_draggable d =
-    let f = function
-      | `True -> "true"
-      | `False -> "false"
-    in user_attrib f "draggable" d
+    bool_attrib "draggable" d
 
   let a_form = string_attrib "form"
 
@@ -568,10 +564,7 @@ module MakeWrapped
     in space_sep_attrib "sandbox" (W.fmap aux sb)
 
   let a_spellcheck sc =
-    let f = function
-      | `True -> "true"
-      | `False -> "false"
-    in user_attrib f "spellckeck" sc
+    bool_attrib "spellckeck" sc
 
   let a_scoped x =
     let f = function

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -55,8 +55,7 @@ module type T = sig
 
   val a_challenge : text wrap -> [> | `Challenge] attrib
 
-  val a_contenteditable :
-    [< | `True | `False] wrap -> [> | `Contenteditable] attrib
+  val a_contenteditable : bool wrap -> [> | `Contenteditable] attrib
 
   val a_contextmenu : idref wrap -> [> | `Contextmenu] attrib
 
@@ -64,7 +63,7 @@ module type T = sig
 
   val a_dir : [< | `Rtl | `Ltr] wrap -> [> | `Dir] attrib
 
-  val a_draggable : [< | `True | `False] wrap -> [> | `Draggable] attrib
+  val a_draggable : bool wrap -> [> | `Draggable] attrib
 
   val a_form : idref wrap -> [> | `Form] attrib
 
@@ -130,7 +129,7 @@ module type T = sig
     [< | `AllowSameOrigin | `AllowForms | `AllowScript] list wrap ->
     [> | `Sandbox] attrib
 
-  val a_spellcheck : [< | `True | `False] wrap -> [> | `Spellcheck] attrib
+  val a_spellcheck : bool wrap -> [> | `Spellcheck] attrib
 
   val a_scoped : [< | `Scoped] wrap -> [> | `Scoped] attrib
 


### PR DESCRIPTION
I'm actually breaking compat with that, which is not nice, but I hope to fix all those small issues and inconsistencies in the tyxml api for the next release (no deadline, though). 

This removes the nonsensical `[< | `True | `False]` and replace it by actual booleans. see joint PR for eliom-widget for the "trigger" of this change.

I will wait a few days before merging this, just to see if someone has some strong arguments against it. :)
