### PR TITLE
Add img and dl types. Change (audio|video)_interactive types.

### DIFF
--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -627,7 +627,7 @@ module type T = sig
       ((([< | `Dt] elt) * (([< | `Dt] elt) list)) *
        (([< | `Dd] elt) * (([< | `Dd] elt) list))) list wrap -> [> | `Dl] elt
    but we simplify into star *)
-  val dl : ([< | common], [< | `Dt | `Dd], [> | `Dl]) star
+  val dl : ([< | dl_attrib], [< | dl_content_fun], [> | dl]) star
 
   val ol : ([< | ol_attrib], [< | ol_content_fun], [> | ol]) star
 
@@ -774,8 +774,7 @@ module type T = sig
   val img :
     src: Xml.uri wrap ->
     alt: text wrap ->
-    ([< | common | `Height | `Ismap | `Width], [> `Img ])
-      nullary
+    ([< img_attrib], [> img]) nullary
 
   val iframe : (*| `Srcdoc*)
     ([< | common | `Src | `Name | `Sandbox | `Seamless | `Width | `Height],
@@ -830,12 +829,12 @@ module type T = sig
   val audio :
     ?src:Xml.uri wrap ->
     ?srcs:(([< | source] elt) list wrap) ->
-    ([< | audio_attrib], 'a, [> | `Audio of 'a ]) star
+    ([< | audio_attrib], 'a, [> 'a audio ]) star
 
   val video :
     ?src:Xml.uri wrap ->
     ?srcs: (([< | source] elt) list wrap) ->
-    ([< | video_attrib], 'a, [> | `Video of 'a]) star
+    ([< | video_attrib], 'a, [> 'a video]) star
 
   val canvas : ([< | canvas_attrib], 'a, [> | 'a canvas]) star
 

--- a/lib/html5_types.mli
+++ b/lib/html5_types.mli
@@ -1398,6 +1398,15 @@ type dt_content_fun = [ | phrasing ]
 type dt_attrib = [ | common ]
 
 
+type dl = [ | `Dl ]
+
+type dl_content = [ | `Dt | `Dd ]
+
+type dl_content_fun = [ | `Dt | `Dd ]
+
+type dl_attrib = [ | common ]
+
+
 (* NAME: figcaption, KIND: star, TYPE: [= common ], [= flow5], [=`Figcaption], ARG: [= flow5], ATTRIB:  OUT: [=`Figcaption] *)
 type figcaption = [ | `Figcaption ]
 
@@ -1697,6 +1706,13 @@ type embed_content_fun = notag
 
 type embed_attrib = [ | common | `Src | `Height | `Mime_type | `Width ]
 
+
+type img = [ `Img ]
+type img_interactive = [ `Img | `Img_interactive ]
+type img_content = notag
+type img_content_fun = notag
+type img_attrib = [ | common | `Height | `Ismap | `Width]
+
 (* Attributes used by audio and video. *)
 type media_attrib =
   [ | `Crossorigin
@@ -1708,7 +1724,8 @@ type media_attrib =
     | `Controls
   ]
 
-type 'a audio = [ | `Audio of 'a | `Audio_interactive of 'a ]
+type 'a audio = [ | `Audio of 'a ]
+type 'a audio_interactive = [ | `Audio of 'a | `Audio_interactive of 'a ]
 
 type audio_content = flow5_without_media
 type audio_ = audio_content audio
@@ -1720,7 +1737,8 @@ type audio_attrib =
   ]
 
 
-type 'a video = [ | `Video of 'a | `Video_interactive of 'a ]
+type 'a video = [ | `Video of 'a ]
+type 'a video_interactive = [ | `Video of 'a | `Video_interactive of 'a ]
 
 type video_content = flow5_without_media
 type video_ = video_content video


### PR DESCRIPTION
The audio and video types are now only for the non-interactive version. There
is an interactive version which is valid for both versions.
