### PR TITLE
Rework wrapping

### DIFF
--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -33,7 +33,7 @@
 open Html5_types
 
 module Make
-    (Xml : Xml_sigs.Wrapped)
+    (Xml : Xml_sigs.T)
     (Svg : Svg_sigs.T with module Xml := Xml)= struct
 
   module Xml = Xml

--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -36,9 +36,10 @@ module MakeWrapped
     (W : Xml_wrap.T)
     (Xml : Xml_sigs.Wrapped with type 'a wrap = 'a W.t
                              and type 'a list_wrap = 'a W.tlist)
-    (Svg : Svg_sigs.T with module Xml := Xml
-                       and type 'a list_wrap = 'a W.tlist)= struct
+    (Svg : Svg_sigs.T with module W = W and module Xml := Xml)= struct
 
+
+  module W = W
   module Xml = Xml
 
   module Info = struct
@@ -1067,8 +1068,7 @@ end
 
 module Make
     (Xml : Xml_sigs.T)
-    (Svg : Svg_sigs.T with module Xml := Xml
-                       and type 'a list_wrap = 'a Xml.list_wrap) =
+    (Svg : Svg_sigs.T with module W = Xml_wrap.NoWrap and module Xml := Xml) =
   MakeWrapped
     (Xml_wrap.NoWrap)
     (Xml)

--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -34,12 +34,9 @@ open Html5_types
 
 module MakeWrapped
     (W : Xml_wrap.T)
-    (Xml : Xml_sigs.Wrapped with type 'a wrap = 'a W.t
-                             and type 'a list_wrap = 'a W.tlist)
-    (Svg : Svg_sigs.T with module W = W and module Xml := Xml)= struct
+    (Xml : Xml_sigs.Wrapped with module W = W)
+    (Svg : Svg_sigs.T with module Xml := Xml)= struct
 
-
-  module W = W
   module Xml = Xml
 
   module Info = struct
@@ -1067,9 +1064,9 @@ module MakeWrapped
 end
 
 module Make
-    (Xml : Xml_sigs.T)
-    (Svg : Svg_sigs.T with module W = Xml_wrap.NoWrap and module Xml := Xml) =
+    (Xml : Xml_sigs.Wrapped)
+    (Svg : Svg_sigs.T with module Xml := Xml) =
   MakeWrapped
-    (Xml_wrap.NoWrap)
+    (Xml.W)
     (Xml)
     (Svg)

--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -32,12 +32,12 @@
 
 open Html5_types
 
-module MakeWrapped
-    (W : Xml_wrap.T)
-    (Xml : Xml_sigs.Wrapped with module W = W)
+module Make
+    (Xml : Xml_sigs.Wrapped)
     (Svg : Svg_sigs.T with module Xml := Xml)= struct
 
   module Xml = Xml
+  module W = Xml.W
 
   module Info = struct
     let content_type = "text/html"
@@ -1062,11 +1062,3 @@ module MakeWrapped
   end
 
 end
-
-module Make
-    (Xml : Xml_sigs.Wrapped)
-    (Svg : Svg_sigs.T with module Xml := Xml) =
-  MakeWrapped
-    (Xml.W)
-    (Xml)
-    (Svg)

--- a/lib/html5_f.mli
+++ b/lib/html5_f.mli
@@ -22,8 +22,8 @@
 (** Typesafe constructors for HTML5 documents (Functorial interface) *)
 
 module Make
-    (Xml : Xml_sigs.T)
-    (Svg : Svg_sigs.T with module W = Xml_wrap.NoWrap and module Xml := Xml)
+    (Xml : Xml_sigs.Wrapped)
+    (Svg : Svg_sigs.T with module Xml := Xml)
   : Html5_sigs.Make(Xml)(Svg).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib
@@ -33,9 +33,8 @@ module Make
     See the functorial interface documentation for more details. *)
 module MakeWrapped
     (W : Xml_wrap.T)
-    (Xml : Xml_sigs.Wrapped with type 'a wrap = 'a W.t
-                             and type 'a list_wrap = 'a W.tlist)
-    (Svg : Svg_sigs.T with module W = W and module Xml := Xml)
+    (Xml : Xml_sigs.Wrapped with module W = W)
+    (Svg : Svg_sigs.T with module Xml := Xml)
   : Html5_sigs.MakeWrapped(W)(Xml)(Svg).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib

--- a/lib/html5_f.mli
+++ b/lib/html5_f.mli
@@ -22,7 +22,7 @@
 (** Typesafe constructors for HTML5 documents (Functorial interface) *)
 
 module Make
-    (Xml : Xml_sigs.Wrapped)
+    (Xml : Xml_sigs.T)
     (Svg : Svg_sigs.T with module Xml := Xml)
   : Html5_sigs.Make(Xml)(Svg).T
     with type +'a elt = Xml.elt

--- a/lib/html5_f.mli
+++ b/lib/html5_f.mli
@@ -27,14 +27,3 @@ module Make
   : Html5_sigs.Make(Xml)(Svg).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib
-
-
-(** Like the {! Html5_f.Make } functor, but allows to wrap elements inside a monad described by {! Xml_wrap.T}.
-    See the functorial interface documentation for more details. *)
-module MakeWrapped
-    (W : Xml_wrap.T)
-    (Xml : Xml_sigs.Wrapped with module W = W)
-    (Svg : Svg_sigs.T with module Xml := Xml)
-  : Html5_sigs.MakeWrapped(W)(Xml)(Svg).T
-    with type +'a elt = Xml.elt
-     and type +'a attrib = Xml.attrib

--- a/lib/html5_f.mli
+++ b/lib/html5_f.mli
@@ -23,8 +23,7 @@
 
 module Make
     (Xml : Xml_sigs.T)
-    (Svg : Svg_sigs.T with module Xml := Xml
-                       and type 'a list_wrap = 'a Xml.list_wrap)
+    (Svg : Svg_sigs.T with module W = Xml_wrap.NoWrap and module Xml := Xml)
   : Html5_sigs.Make(Xml)(Svg).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib
@@ -36,8 +35,7 @@ module MakeWrapped
     (W : Xml_wrap.T)
     (Xml : Xml_sigs.Wrapped with type 'a wrap = 'a W.t
                              and type 'a list_wrap = 'a W.tlist)
-    (Svg : Svg_sigs.T with module Xml := Xml
-                       and type 'a list_wrap = 'a Xml.list_wrap)
+    (Svg : Svg_sigs.T with module W = W and module Xml := Xml)
   : Html5_sigs.MakeWrapped(W)(Xml)(Svg).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -21,7 +21,7 @@ module type T = sig
 
   open Html5_types
 
-  module Xml : Xml_sigs.Wrapped
+  module Xml : Xml_sigs.T
 
   module Svg : Svg_sigs.T with module Xml := Xml
 
@@ -1188,12 +1188,14 @@ module type T = sig
 
 end
 
+module type NoWrap = T with module Xml.W = Xml_wrap.NoWrap
+
 (** {2 Signature functors} *)
 (** See {% <<a_manual chapter="functors"|the manual of the functorial interface>> %}. *)
 
-(** Signature functor for {!Html5_f.MakeWrapped}. *)
+(** Signature functor for {!Html5_f.Make}. *)
 module Make
-    (Xml : Xml_sigs.Wrapped)
+    (Xml : Xml_sigs.T)
     (Svg : Svg_sigs.T with module Xml := Xml) :
 sig
 

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -21,19 +21,14 @@ module type T = sig
 
   open Html5_types
 
-  module W : Xml_wrap.T
-
   module Xml : Xml_sigs.Wrapped
-    with type 'a wrap = 'a W.t and type 'a list_wrap = 'a W.tlist
 
-  module Svg : Svg_sigs.T
-    with module W = W and module Xml := Xml
-    with type 'a wrap = 'a W.t and type 'a list_wrap = 'a W.tlist
+  module Svg : Svg_sigs.T with module Xml := Xml
 
   module Info : Xml_sigs.Info
 
-  type 'a wrap = 'a W.t
-  type 'a list_wrap = 'a W.tlist
+  type 'a wrap = 'a Xml.W.t
+  type 'a list_wrap = 'a Xml.W.tlist
 
   type uri = Xml.uri
   val string_of_uri : uri -> string
@@ -1199,15 +1194,14 @@ end
 (** Signature functor for {!Html5_f.MakeWrapped}. *)
 module MakeWrapped
     (W : Xml_wrap.T)
-    (Xml : Xml_sigs.Wrapped
-     with type 'a wrap = 'a W.t and type 'a list_wrap = 'a W.tlist)
-    (Svg : Svg_sigs.T with module W = W and module Xml := Xml) :
+    (Xml : Xml_sigs.Wrapped with module W = W)
+    (Svg : Svg_sigs.T with module Xml := Xml) :
 sig
 
   (** See {!modtype:Html5_sigs.T}. *)
   module type T = T
-    with type 'a W.t = 'a W.t
-     and type 'a W.tlist = 'a W.tlist
+    with type 'a Xml.W.t = 'a Xml.W.t
+     and type 'a Xml.W.tlist = 'a Xml.W.tlist
      and type Xml.uri = Xml.uri
      and type Xml.event_handler = Xml.event_handler
      and type Xml.mouse_event_handler = Xml.mouse_event_handler
@@ -1219,10 +1213,10 @@ end
 
 (** Signature functor for {!Html5_f.Make}. *)
 module Make
-    (Xml : Xml_sigs.T)
-    (Svg : Svg_sigs.T with module W = Xml_wrap.NoWrap and module Xml := Xml) :
+    (Xml : Xml_sigs.Wrapped)
+    (Svg : Svg_sigs.T with module Xml := Xml) :
 sig
 
   (** See {!modtype:Html5_sigs.MakeWrapped} and {!modtype:Html5_sigs.T}. *)
-  module type T = MakeWrapped(Xml_wrap.NoWrap)(Xml)(Svg).T
+  module type T = MakeWrapped(Xml.W)(Xml)(Svg).T
 end

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -21,12 +21,19 @@ module type T = sig
 
   open Html5_types
 
+  module W : Xml_wrap.T
+
   module Xml : Xml_sigs.Wrapped
-  module Svg : Svg_sigs.T with module Xml := Xml
+    with type 'a wrap = 'a W.t and type 'a list_wrap = 'a W.tlist
+
+  module Svg : Svg_sigs.T
+    with module W = W and module Xml := Xml
+    with type 'a wrap = 'a W.t and type 'a list_wrap = 'a W.tlist
+
   module Info : Xml_sigs.Info
 
-  type 'a wrap
-  type 'a list_wrap
+  type 'a wrap = 'a W.t
+  type 'a list_wrap = 'a W.tlist
 
   type uri = Xml.uri
   val string_of_uri : uri -> string
@@ -1192,29 +1199,28 @@ end
 (** Signature functor for {!Html5_f.MakeWrapped}. *)
 module MakeWrapped
     (W : Xml_wrap.T)
-    (Xml : Xml_sigs.Wrapped)
-    (Svg : Svg_sigs.T with module Xml := Xml) :
+    (Xml : Xml_sigs.Wrapped
+     with type 'a wrap = 'a W.t and type 'a list_wrap = 'a W.tlist)
+    (Svg : Svg_sigs.T with module W = W and module Xml := Xml) :
 sig
 
   (** See {!modtype:Html5_sigs.T}. *)
   module type T = T
-    with type Xml.uri = Xml.uri
+    with type 'a W.t = 'a W.t
+     and type 'a W.tlist = 'a W.tlist
+     and type Xml.uri = Xml.uri
      and type Xml.event_handler = Xml.event_handler
      and type Xml.mouse_event_handler = Xml.mouse_event_handler
      and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
      and type Xml.attrib = Xml.attrib
      and type Xml.elt = Xml.elt
      and module Svg := Svg
-     and type 'a Xml.wrap = 'a W.t
-     and type 'a wrap = 'a W.t
-     and type 'a Xml.list_wrap = 'a W.tlist
-     and type 'a list_wrap = 'a W.tlist
 end
 
 (** Signature functor for {!Html5_f.Make}. *)
 module Make
     (Xml : Xml_sigs.T)
-    (Svg : Svg_sigs.T with module Xml := Xml) :
+    (Svg : Svg_sigs.T with module W = Xml_wrap.NoWrap and module Xml := Xml) :
 sig
 
   (** See {!modtype:Html5_sigs.MakeWrapped} and {!modtype:Html5_sigs.T}. *)

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -1192,9 +1192,8 @@ end
 (** See {% <<a_manual chapter="functors"|the manual of the functorial interface>> %}. *)
 
 (** Signature functor for {!Html5_f.MakeWrapped}. *)
-module MakeWrapped
-    (W : Xml_wrap.T)
-    (Xml : Xml_sigs.Wrapped with module W = W)
+module Make
+    (Xml : Xml_sigs.Wrapped)
     (Svg : Svg_sigs.T with module Xml := Xml) :
 sig
 
@@ -1209,14 +1208,4 @@ sig
      and type Xml.attrib = Xml.attrib
      and type Xml.elt = Xml.elt
      and module Svg := Svg
-end
-
-(** Signature functor for {!Html5_f.Make}. *)
-module Make
-    (Xml : Xml_sigs.Wrapped)
-    (Svg : Svg_sigs.T with module Xml := Xml) :
-sig
-
-  (** See {!modtype:Html5_sigs.MakeWrapped} and {!modtype:Html5_sigs.T}. *)
-  module type T = MakeWrapped(Xml.W)(Xml)(Svg).T
 end

--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -135,7 +135,7 @@ let string_of_paint = function
     (string_of_iri iri) ^" "^ (string_of_paint_whitout_icc b)
   | #paint_whitout_icc as c -> string_of_paint_whitout_icc c
 
-module Make (Xml : Xml_sigs.Wrapped) =
+module Make (Xml : Xml_sigs.T) =
 struct
 
   module Xml = Xml

--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -141,6 +141,7 @@ module MakeWrapped
                              and type 'a list_wrap = 'a W.tlist) =
 struct
 
+  module W = W
   module Xml = Xml
 
   module Info = struct

--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -135,12 +135,11 @@ let string_of_paint = function
     (string_of_iri iri) ^" "^ (string_of_paint_whitout_icc b)
   | #paint_whitout_icc as c -> string_of_paint_whitout_icc c
 
-module MakeWrapped
-    (W : Xml_wrap.T)
-    (Xml : Xml_sigs.Wrapped with module W = W) =
+module Make (Xml : Xml_sigs.Wrapped) =
 struct
 
   module Xml = Xml
+  module W = Xml.W
 
   module Info = struct
     let content_type = "image/svg+xml"
@@ -1138,8 +1137,3 @@ struct
   end
 
 end
-
-module Make(Xml : Xml_sigs.Wrapped) =
-  MakeWrapped
-    (Xml.W)
-    (Xml)

--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -137,11 +137,9 @@ let string_of_paint = function
 
 module MakeWrapped
     (W : Xml_wrap.T)
-    (Xml : Xml_sigs.Wrapped with type 'a wrap = 'a W.t
-                             and type 'a list_wrap = 'a W.tlist) =
+    (Xml : Xml_sigs.Wrapped with module W = W) =
 struct
 
-  module W = W
   module Xml = Xml
 
   module Info = struct
@@ -1141,7 +1139,7 @@ struct
 
 end
 
-module Make(Xml : Xml_sigs.T) =
+module Make(Xml : Xml_sigs.Wrapped) =
   MakeWrapped
-    (Xml_wrap.NoWrap)
+    (Xml.W)
     (Xml)

--- a/lib/svg_f.mli
+++ b/lib/svg_f.mli
@@ -80,7 +80,7 @@ val string_of_transform : transform -> string
 val string_of_transforms : transforms -> string
 *)
 
-module Make(Xml : Xml_sigs.T)
+module Make(Xml : Xml_sigs.Wrapped)
   : Svg_sigs.Make(Xml).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib
@@ -89,8 +89,7 @@ module Make(Xml : Xml_sigs.T)
     See the functorial interface documentation for more details. *)
 module MakeWrapped
     (W: Xml_wrap.T)
-    (Xml : Xml_sigs.Wrapped with type 'a wrap = 'a W.t
-                             and type 'a list_wrap = 'a W.tlist)
+    (Xml : Xml_sigs.Wrapped with module W = W)
   : Svg_sigs.MakeWrapped(W)(Xml).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib

--- a/lib/svg_f.mli
+++ b/lib/svg_f.mli
@@ -84,12 +84,3 @@ module Make(Xml : Xml_sigs.Wrapped)
   : Svg_sigs.Make(Xml).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib
-
-(** Like the {! Svg_f.Make } functor, but allows to wrap elements inside a monad described by {! Xml_wrap.T}.
-    See the functorial interface documentation for more details. *)
-module MakeWrapped
-    (W: Xml_wrap.T)
-    (Xml : Xml_sigs.Wrapped with module W = W)
-  : Svg_sigs.MakeWrapped(W)(Xml).T
-    with type +'a elt = Xml.elt
-     and type +'a attrib = Xml.attrib

--- a/lib/svg_f.mli
+++ b/lib/svg_f.mli
@@ -80,7 +80,7 @@ val string_of_transform : transform -> string
 val string_of_transforms : transforms -> string
 *)
 
-module Make(Xml : Xml_sigs.Wrapped)
+module Make(Xml : Xml_sigs.T)
   : Svg_sigs.Make(Xml).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -22,7 +22,7 @@ module type T = sig
   open Svg_types
   open Unit
 
-  module Xml : Xml_sigs.Wrapped
+  module Xml : Xml_sigs.T
   module Info : Xml_sigs.Info
 
   type uri = Xml.uri
@@ -890,13 +890,13 @@ module type T = sig
 
 end
 
+module type NoWrap = T with module Xml.W = Xml_wrap.NoWrap
+
 (** {2 Signature functors} *)
 (** See {% <<a_manual chapter="functors"|the manual of the functorial interface>> %}. *)
 
-(** Signature functor for {!Svg_f.MakeWrapped}. *)
-module Make
-    (Xml : Xml_sigs.Wrapped) :
-sig
+(** Signature functor for {!Svg_f.Make}. *)
+module Make (Xml : Xml_sigs.T) : sig
 
   (** See {!modtype:Svg_sigs.T}. *)
   module type T = T
@@ -908,4 +908,5 @@ sig
      and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
      and type Xml.attrib = Xml.attrib
      and type Xml.elt = Xml.elt
+
 end

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -894,9 +894,8 @@ end
 (** See {% <<a_manual chapter="functors"|the manual of the functorial interface>> %}. *)
 
 (** Signature functor for {!Svg_f.MakeWrapped}. *)
-module MakeWrapped
-    (W : Xml_wrap.T)
-    (Xml : Xml_sigs.Wrapped with module W = W) :
+module Make
+    (Xml : Xml_sigs.Wrapped) :
 sig
 
   (** See {!modtype:Svg_sigs.T}. *)
@@ -909,12 +908,4 @@ sig
      and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
      and type Xml.attrib = Xml.attrib
      and type Xml.elt = Xml.elt
-end
-
-(** Signature functor for {!Svg_f.Make}. *)
-module Make(Xml : Xml_sigs.Wrapped) :
-sig
-
-  (** See {!modtype:Svg_sigs.MakeWrapped} and {!modtype:Svg_sigs.T}. *)
-  module type T = MakeWrapped(Xml.W)(Xml).T
 end

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -22,7 +22,9 @@ module type T = sig
   open Svg_types
   open Unit
 
+  module W : Xml_wrap.T
   module Xml : Xml_sigs.Wrapped
+    with type 'a wrap = 'a W.t and type 'a list_wrap = 'a W.tlist
   module Info : Xml_sigs.Info
 
   type uri = Xml.uri
@@ -33,8 +35,8 @@ module type T = sig
 
   type +'a attrib
 
-  type 'a wrap
-  type 'a list_wrap
+  type 'a wrap = 'a W.t
+  type 'a list_wrap = 'a W.tlist
 
   type +'a elt
 
@@ -901,16 +903,14 @@ sig
 
   (** See {!modtype:Svg_sigs.T}. *)
   module type T = T
-    with type Xml.uri = Xml.uri
+    with type 'a W.t = 'a W.t
+     and type 'a W.tlist = 'a W.tlist
+     and type Xml.uri = Xml.uri
      and type Xml.event_handler = Xml.event_handler
      and type Xml.mouse_event_handler = Xml.mouse_event_handler
      and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
      and type Xml.attrib = Xml.attrib
      and type Xml.elt = Xml.elt
-     and type 'a Xml.wrap = 'a W.t
-     and type 'a wrap = 'a W.t
-     and type 'a Xml.list_wrap = 'a W.tlist
-     and type 'a list_wrap = 'a W.tlist
 end
 
 (** Signature functor for {!Svg_f.Make}. *)

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -22,9 +22,7 @@ module type T = sig
   open Svg_types
   open Unit
 
-  module W : Xml_wrap.T
   module Xml : Xml_sigs.Wrapped
-    with type 'a wrap = 'a W.t and type 'a list_wrap = 'a W.tlist
   module Info : Xml_sigs.Info
 
   type uri = Xml.uri
@@ -35,8 +33,8 @@ module type T = sig
 
   type +'a attrib
 
-  type 'a wrap = 'a W.t
-  type 'a list_wrap = 'a W.tlist
+  type 'a wrap = 'a Xml.W.t
+  type 'a list_wrap = 'a Xml.W.tlist
 
   type +'a elt
 
@@ -898,13 +896,13 @@ end
 (** Signature functor for {!Svg_f.MakeWrapped}. *)
 module MakeWrapped
     (W : Xml_wrap.T)
-    (Xml : Xml_sigs.Wrapped) :
+    (Xml : Xml_sigs.Wrapped with module W = W) :
 sig
 
   (** See {!modtype:Svg_sigs.T}. *)
   module type T = T
-    with type 'a W.t = 'a W.t
-     and type 'a W.tlist = 'a W.tlist
+    with type 'a Xml.W.t = 'a Xml.W.t
+     and type 'a Xml.W.tlist = 'a Xml.W.tlist
      and type Xml.uri = Xml.uri
      and type Xml.event_handler = Xml.event_handler
      and type Xml.mouse_event_handler = Xml.mouse_event_handler
@@ -914,9 +912,9 @@ sig
 end
 
 (** Signature functor for {!Svg_f.Make}. *)
-module Make(Xml : Xml_sigs.T) :
+module Make(Xml : Xml_sigs.Wrapped) :
 sig
 
   (** See {!modtype:Svg_sigs.MakeWrapped} and {!modtype:Svg_sigs.T}. *)
-  module type T = MakeWrapped(Xml_wrap.NoWrap)(Xml).T
+  module type T = MakeWrapped(Xml.W)(Xml).T
 end

--- a/lib/xml.ml
+++ b/lib/xml.ml
@@ -23,6 +23,8 @@
 
 module M = struct
 
+  module W = Xml_wrap.NoWrap
+
   type 'a wrap = 'a
   type 'a list_wrap = 'a list
 

--- a/lib/xml.mli
+++ b/lib/xml.mli
@@ -23,7 +23,7 @@
 
 type 'a wrap = 'a
 type 'a list_wrap = 'a list
-module W = Xml_wrap.NoWrap
+module W : Xml_wrap.NoWrap
 type uri = string
 val string_of_uri : uri -> string
 val uri_of_string : string -> uri

--- a/lib/xml.mli
+++ b/lib/xml.mli
@@ -23,6 +23,7 @@
 
 type 'a wrap = 'a
 type 'a list_wrap = 'a list
+module W = Xml_wrap.NoWrap
 type uri = string
 val string_of_uri : uri -> string
 val uri_of_string : string -> uri

--- a/lib/xml_sigs.mli
+++ b/lib/xml_sigs.mli
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
 *)
 
-module type Wrapped = sig
+module type T = sig
 
   module W : Xml_wrap.T
 
@@ -66,10 +66,10 @@ module type Wrapped = sig
 
 end
 
-module type T = Wrapped with module W = Xml_wrap.NoWrap
+module type NoWrap = T with module W = Xml_wrap.NoWrap
 module type Iterable = sig
 
-  include T
+  include NoWrap
 
   type separator = Space | Comma
 
@@ -115,7 +115,7 @@ end
 
 module type Typed_xml = sig
 
-  module Xml : T
+  module Xml : NoWrap
   module Info : Info
 
   type 'a elt

--- a/lib/xml_sigs.mli
+++ b/lib/xml_sigs.mli
@@ -20,8 +20,10 @@
 
 module type Wrapped = sig
 
-  type 'a wrap
-  type 'a list_wrap
+  module W : Xml_wrap.T
+
+  type 'a wrap = 'a W.t
+  type 'a list_wrap = 'a W.tlist
 
   type uri
   val string_of_uri : uri -> string
@@ -64,8 +66,7 @@ module type Wrapped = sig
 
 end
 
-module type T = Wrapped with type 'a wrap = 'a
-                         and type 'a list_wrap = 'a list
+module type T = Wrapped with module W = Xml_wrap.NoWrap
 module type Iterable = sig
 
   include T

--- a/lib/xml_wrap.ml
+++ b/lib/xml_wrap.ml
@@ -31,6 +31,9 @@ module type T = sig
   val map : ('a -> 'b) -> 'a tlist -> 'b tlist
 end
 
+module type NoWrap =
+  T with type 'a t = 'a and type 'a tlist = 'a list
+
 module NoWrap = struct
   type 'a t = 'a
   type 'a tlist = 'a list

--- a/lib/xml_wrap.mli
+++ b/lib/xml_wrap.mli
@@ -30,5 +30,7 @@ module type T = sig
   val map : ('a -> 'b ) -> 'a tlist -> 'b tlist
 end
 
-module NoWrap : T with type 'a t = 'a
-                   and type 'a tlist = 'a list
+module type NoWrap =
+  T with type 'a t = 'a and type 'a tlist = 'a list
+
+module NoWrap : NoWrap


### PR DESCRIPTION
This removes all the wrapped functor, simplify most signatures and remove the need for two arguments to use `Html5` signature (see [this](https://github.com/Drup/ocaml-markdown/commit/aab07fa115e2a72e78db09bfc7e50f8228ac678f)). 

This is done by adding a `W` module to `Xml` everywhere so that, given an `Xml` module (and, by extension, an `Html5` or `Svg` modules containing one, and all of them should), you can use the basic operations on the wrapped element.
The `'a wrap` and `'a list_wrap` are now just aliases. 

It also normalize the naming scheme. Every signatures (`Xml`, `Xml_wrap`, `Svg`, `Html5`) comes in two versions, the `T` version, which is the normal, fully general one and the `NoWrap` version, which comes with the forced equality `Xml.W = Xml_wrap.NoWrap`. 

It's breaking for everyone using the functorized interface but that's all.

In the future, we could provide a small functor taking a `W` and producing a minimal "standard library", I don't know if it's needed.

Basically, I did it painfully wrong the first time, and this fixes it. Sorry about it. :/
cc @darioteixeira, as he's our main user of tyxml's signatures.

@darioteixeira, the change needed after this for camlhighlight is implemented [here](https://github.com/Drup/camlhighlight/commit/5217053d4cadad99d986ef615a08f4cdc49b35ec). To accept an arbitrary wrapping, you replace the `NoWrap` by `T` and use the operations in `Html.Xml.W`.