### PR TITLE
Add `a_lang` for html.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 ===== dev ====
 
+  * Add `a_lang` for HTML. Deprecate `a_srclang` in favor of `a_xml_lang`.
+
 ===== 3.3.0 ====
 
   * Add `Xml_print.Utf8` to encode html elements to utf8 properly.

--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -169,6 +169,7 @@ module MakeWrapped
 
   (* I18N: *)
   let a_xml_lang = string_attrib "xml:lang"
+  let a_lang = string_attrib "lang"
 
   (* Style: *)
   let a_style = string_attrib "style"

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -147,7 +147,7 @@ module type T = sig
 
   val a_span : number wrap -> [> | `Span] attrib
 
-  (*val a_srcdoc*)
+  (** This attribute is deprecated, you should use {! a_xml_lang}. *)
   val a_srclang : nmtoken wrap -> [> | `XML_lang] attrib
 
   val a_start : number wrap -> [> | `Start] attrib
@@ -188,7 +188,9 @@ module type T = sig
 
   (** {2 I18N} *)
 
-  val a_xml_lang : nmtoken wrap -> [> | `XML_lang] attrib
+  val a_xml_lang : languagecode wrap -> [> | `XML_lang] attrib
+
+  val a_lang : languagecode wrap -> [> | `Lang] attrib
 
   (** {2 Events} *)
 

--- a/lib/html5_types.mli
+++ b/lib/html5_types.mli
@@ -105,7 +105,7 @@ type frametarget = string
 (** Frame name used as destination for results of certain actions. *)
 
 type languagecode = string
-(** A language code, as per RFC5646.
+(** A language code, as per RFC5646/BCP47.
     @see <http://tools.ietf.org/html/rfc5646> RFC5646 *)
 
 type length = [ | `Pixels of int | `Percent of int ]
@@ -284,7 +284,7 @@ type text = string
 
 (** {2 Core} *)
 
-type i18n = [ | `XML_lang ]
+type i18n = [ | `XML_lang | `Lang ]
 
 type core =
   [


### PR DESCRIPTION
There you go @edwintorok. It should be valid according to the spec, but I prefer a second pair of eyes.

Should we do something for Svg (cc @FlorentBecker potentially) ?
