### PR TITLE
Add 3 values to sandbox attribute.

### DIFF
--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -500,6 +500,9 @@ module MakeWrapped
       | `AllowSameOrigin :: a -> "allow-same-origin" :: (aux a)
       | `AllowForms :: a -> "allow-forms" :: (aux a)
       | `AllowScript :: a -> "allow-script" :: (aux a)
+      | `AllowPointerLock :: a -> "allow-pointer-lock" :: (aux a)
+      | `AllowPopups :: a -> "allow-popups" :: (aux a)
+      | `AllowTopNavigation :: a -> "allow-top-navigation" :: (aux a)
       | [] -> []
     in space_sep_attrib "sandbox" (W.fmap aux sb)
 

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -134,7 +134,13 @@ module type T = sig
   val a_reversed : [< | `Reversed] wrap -> [> | `Reversed] attrib
 
   val a_sandbox :
-    [< | `AllowSameOrigin | `AllowForms | `AllowScript] list wrap ->
+    [< 
+     | `AllowSameOrigin 
+     | `AllowForms 
+     | `AllowScript
+     | `AllowPointerLock
+     | `AllowPopups
+     | `AllowTopNavigation ] list wrap ->
     [> | `Sandbox] attrib
 
   val a_spellcheck : bool wrap -> [> | `Spellcheck] attrib


### PR DESCRIPTION
This pull request adds allow-pointer-lock, allow-popups, allow-top-navigation values to sandbox attribute.

Values are taken from [here](http://www.w3.org/TR/html5/embedded-content-0.html#attr-iframe-sandbox).
