### PR TITLE
Special case the img tag in the camlp4 extension.

### DIFF
--- a/syntax/pa_tyxml.ml
+++ b/syntax/pa_tyxml.ml
@@ -136,7 +136,10 @@ module Parser5 = Xhtmlparser.Make(Syntax)(struct
       | tag -> String.capitalize tag ] in
     <:ctyp< Html5.attrib [> `$uid:tag$ ] >>;
   value make_attribs_type _loc tag =
-    <:ctyp< Html5.attrib [< Html5_types.$lid:String.lowercase tag^"_attrib"$] >>;
+    match String.lowercase tag with
+    [ "img" -> <:ctyp< Html5.attrib [< `Alt | `Src | Html5_types.img_attrib] >>
+    | tag -> <:ctyp< Html5.attrib [< Html5_types.$lid:tag^"_attrib"$] >>
+    ] ;
 end);
 
 


### PR DESCRIPTION
Side effect: in the syntax extension, the fact that src and alt
are mandatory in img is not enforced.
Fix #66
