### PR TITLE
Add constructor functions for missing text attributes

### DIFF
--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -339,20 +339,20 @@ struct
 
   let a_textlength = user_attrib string_of_length "textLength"
 
-  let a_textanchor x =
+  let a_text_anchor x =
     let f = function
       | `Start -> "start" | `Middle -> "middle"
       | `End -> "end" | `Inherit -> "inherit" in
     user_attrib f "text-anchor" x
 
-  let a_textdecoration x =
+  let a_text_decoration x =
     let f = function
       | `None -> "none" | `Underline -> "underline"
-      | `Overline -> "overline" | `Linethrough -> "line-through"
+      | `Overline -> "overline" | `Line_through -> "line-through"
       | `Blink -> "blink" | `Inherit -> "inherit" in
     user_attrib f "text-decoration" x
 
-  let a_textrendering x =
+  let a_text_rendering x =
     let f = function
       | `Auto -> "auto"
       | `OptimizeSpeed -> "optimizeSpeed"

--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -339,6 +339,28 @@ struct
 
   let a_textlength = user_attrib string_of_length "textLength"
 
+  let a_textanchor x =
+    let f = function
+      | `Start -> "start" | `Middle -> "middle"
+      | `End -> "end" | `Inherit -> "inherit" in
+    user_attrib f "text-anchor" x
+
+  let a_textdecoration x =
+    let f = function
+      | `None -> "none" | `Underline -> "underline"
+      | `Overline -> "overline" | `Linethrough -> "line-through"
+      | `Blink -> "blink" | `Inherit -> "inherit" in
+    user_attrib f "text-decoration" x
+
+  let a_textrendering x =
+    let f = function
+      | `Auto -> "auto"
+      | `OptimizeSpeed -> "optimizeSpeed"
+      | `OptimizeLegibility -> "optimizeLegibility"
+      | `GeometricPrecision -> "geometricPrecision"
+      | `Inherit -> "inherit" in
+    user_attrib f "text-rendering" x
+
   let a_rotate = user_attrib string_of_numbers "rotate"
 
   let a_startoffset = user_attrib string_of_length "startOffset"

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -150,11 +150,11 @@ module type T = sig
 
   val a_textlength : Unit.length wrap -> [> | `TextLength ] attrib
 
-  val a_textanchor : [< `Start | `Middle | `End | `Inherit ] wrap -> [> | `Text_Anchor ] attrib
+  val a_text_anchor : [< `Start | `Middle | `End | `Inherit ] wrap -> [> | `Text_Anchor ] attrib
 
-  val a_textdecoration : [< `None | `Underline | `Overline | `Linethrough | `Blink | `Inherit ] wrap -> [> | `Text_Decoration ] attrib
+  val a_text_decoration : [< `None | `Underline | `Overline | `Line_through | `Blink | `Inherit ] wrap -> [> | `Text_Decoration ] attrib
 
-  val a_textrendering : [< `Auto | `OptimizeSpeed | `OptimizeLegibility | `GeometricPrecision | `Inherit ] wrap -> [> | `Text_Rendering ] attrib
+  val a_text_rendering : [< `Auto | `OptimizeSpeed | `OptimizeLegibility | `GeometricPrecision | `Inherit ] wrap -> [> | `Text_Rendering ] attrib
 
   val a_rotate : numbers wrap -> [> | `Rotate ] attrib
 

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -150,6 +150,12 @@ module type T = sig
 
   val a_textlength : Unit.length wrap -> [> | `TextLength ] attrib
 
+  val a_textanchor : [< `Start | `Middle | `End | `Inherit ] wrap -> [> | `Text_Anchor ] attrib
+
+  val a_textdecoration : [< `None | `Underline | `Overline | `Linethrough | `Blink | `Inherit ] wrap -> [> | `Text_Decoration ] attrib
+
+  val a_textrendering : [< `Auto | `OptimizeSpeed | `OptimizeLegibility | `GeometricPrecision | `Inherit ] wrap -> [> | `Text_Rendering ] attrib
+
   val a_rotate : numbers wrap -> [> | `Rotate ] attrib
 
   val a_startoffset : Unit.length wrap -> [> | `StartOffset ] attrib


### PR DESCRIPTION
I tried to keep the same conventions already used in Tyxml.  I just wasn't sure about `linethrough`: should it be `lineThrough` or `line_through` instead?