### PR TITLE
Fix svg element creation in Html5

### DIFF
--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -928,13 +928,8 @@ module MakeWrapped
 
   let form = star "form"
 
-  let svg ?(xmlns = "http://www.w3.org/2000/svg") ?(a = []) children =
-    let xmlns = string_attrib "xmlns" (W.return xmlns) in
-    let xmlns_xlink =
-      string_attrib "xmlns:xlink" (W.return "http://www.w3.org/1999/xlink")
-    in
-    let attribs = Svg.to_attrib xmlns :: Svg.to_attrib xmlns_xlink :: a in
-    Svg.toelt (Svg.svg ~a:attribs children)
+  let svg ?(a = []) children =
+    Svg.toelt (Svg.svg ~a children)
 
   let input = terminal "input"
 

--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -36,7 +36,8 @@ module MakeWrapped
     (W : Xml_wrap.T)
     (Xml : Xml_sigs.Wrapped with type 'a wrap = 'a W.t
                              and type 'a list_wrap = 'a W.tlist)
-    (Svg : Svg_sigs.T with module Xml := Xml)= struct
+    (Svg : Svg_sigs.T with module Xml := Xml
+                       and type 'a list_wrap = 'a W.tlist)= struct
 
   module Xml = Xml
 
@@ -928,13 +929,12 @@ module MakeWrapped
   let form = star "form"
 
   let svg ?(xmlns = "http://www.w3.org/2000/svg") ?(a = []) children =
-    let attribs =
-      string_attrib "xmlns" (W.return xmlns)
-      :: string_attrib "xmlns:xlink" (W.return "http://www.w3.org/1999/xlink")
-      :: Svg.to_xmlattribs a
+    let xmlns = string_attrib "xmlns" (W.return xmlns) in
+    let xmlns_xlink =
+      string_attrib "xmlns:xlink" (W.return "http://www.w3.org/1999/xlink")
     in
-    star ~a:(attribs)
-      "svg" (W.map Svg.toelt children)
+    let attribs = Svg.to_attrib xmlns :: Svg.to_attrib xmlns_xlink :: a in
+    Svg.toelt (Svg.svg ~a:attribs children)
 
   let input = terminal "input"
 
@@ -1072,7 +1072,8 @@ end
 
 module Make
     (Xml : Xml_sigs.T)
-    (Svg : Svg_sigs.T with module Xml := Xml) =
+    (Svg : Svg_sigs.T with module Xml := Xml
+                       and type 'a list_wrap = 'a Xml.list_wrap) =
   MakeWrapped
     (Xml_wrap.NoWrap)
     (Xml)

--- a/lib/html5_f.mli
+++ b/lib/html5_f.mli
@@ -23,7 +23,8 @@
 
 module Make
     (Xml : Xml_sigs.T)
-    (Svg : Svg_sigs.T with module Xml := Xml)
+    (Svg : Svg_sigs.T with module Xml := Xml
+                       and type 'a list_wrap = 'a Xml.list_wrap)
   : Html5_sigs.Make(Xml)(Svg).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib
@@ -35,7 +36,8 @@ module MakeWrapped
     (W : Xml_wrap.T)
     (Xml : Xml_sigs.Wrapped with type 'a wrap = 'a W.t
                              and type 'a list_wrap = 'a W.tlist)
-    (Svg : Svg_sigs.T with module Xml := Xml)
+    (Svg : Svg_sigs.T with module Xml := Xml
+                       and type 'a list_wrap = 'a Xml.list_wrap)
   : Html5_sigs.MakeWrapped(W)(Xml)(Svg).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -561,7 +561,7 @@ module type T = sig
   val body : ([< | body_attrib], [< | body_content_fun], [> | body]) star
 
 
-  val svg : ?xmlns : string -> ?a : [< svg_attrib ] Svg.attrib list -> [< svg_content ] Svg.elt list_wrap -> [> svg ] elt
+  val svg : ?a : [< svg_attrib ] Svg.attrib list -> [< svg_content ] Svg.elt list_wrap -> [> svg ] elt
 
   (** {2 Section} *)
 

--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -919,7 +919,8 @@ struct
   *)
   let svg ?(a = []) children =
     let attribs =
-      string_attrib "xmlns:xlink" (W.return "http://www.w3.org/1999/xlink")
+      string_attrib "xmlns" (W.return "http://www.w3.org/2000/svg")
+      :: string_attrib "xmlns:xlink" (W.return "http://www.w3.org/1999/xlink")
       :: to_xmlattribs a
     in
     star ~a:(attribs) "svg" (W.map toeltl children)


### PR DESCRIPTION
This PR follows from a suggestion by @Drup in an [jsoo issue](ocsigen/js_of_ocaml#276).

Description:
Use [Svg.svg] to create an svg embedded in a [Html5.elt] instead of [Xml.node].