### PR TITLE
Allowing SVG attributes: class in text; {alignment,dominant}-baseline

### DIFF
--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -849,6 +849,41 @@ struct
 
   let a_name = string_attrib "name"
 
+  let string_of_alignment_baseline = function
+    | `Auto -> "auto"
+    | `Baseline -> "baseline"
+    | `Before_edge -> "before-edge"
+    | `Text_before_edge -> "text-before-edge"
+    | `Middle -> "middle"
+    | `Central -> "central"
+    | `After_edge -> "after-edge"
+    | `Text_after_edge -> "text-after-edge"
+    | `Ideographic -> "ideographic"
+    | `Alphabetic -> "alphabetic"
+    | `Hanging-> "hanging"
+    | `Mathematical -> "mathematical"
+    | `Inherit -> "inherit"
+
+  let a_alignment_baseline =
+    user_attrib string_of_alignment_baseline "alignment-baseline"
+
+  let string_of_dominant_baseline = function
+    | `Auto -> "auto"
+    | `Use_script -> "use-script"
+    | `No_change -> "no-change"
+    | `Reset_size -> "reset-size"
+    | `Ideographic -> "ideographic"
+    | `Alphabetic -> "alphabetic"
+    | `Hanging -> "hanging"
+    | `Mathematical -> "mathematical"
+    | `Central -> "central"
+    | `Middle -> "middle"
+    | `Text_after_edge -> "text-after-edge"
+    | `Text_before_edge -> "text-before-edge"
+    | `Inherit -> "inherit"
+
+  let a_dominant_baseline =
+    user_attrib string_of_dominant_baseline "dominant-baseline"
 
   (** Javascript events *)
 

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -529,6 +529,17 @@ module type T = sig
 
   val a_name : string wrap -> [> | `Name ] attrib
 
+  val a_alignment_baseline :
+    [< | `Auto | `Baseline | `Before_edge | `Text_before_edge | `Middle
+       | `Central | `After_edge | `Text_after_edge | `Ideographic
+       | `Alphabetic | `Hanging | `Mathematical | `Inherit ] wrap ->
+    [> | `Alignment_Baseline ] attrib
+
+  val a_dominant_baseline :
+    [< | `Auto | `Use_script | `No_change | `Reset_size | `Ideographic
+       | `Alphabetic | `Hanging | `Mathematical | `Central | `Middle
+       | `Text_after_edge | `Text_before_edge | `Inherit ] wrap ->
+    [> | `Dominant_Baseline ] attrib
 
   (** Javascript events *)
 

--- a/lib/svg_types.mli
+++ b/lib/svg_types.mli
@@ -162,7 +162,6 @@ type animation_addition_attr = [ | `Additive | `Accumulate ]
 
 type presentation_attr =
   [
-    | `Alignement_Baseline
     | `Baseline_Shift
     | `Clip
     | `Clip_Path
@@ -175,7 +174,7 @@ type presentation_attr =
     | `Cursor
     | `Direction
     | `Display
-    | `Dominant_baseline
+    | `Dominant_Baseline
     | `Enable_background
     | `Fill
     | `Fill_opacity
@@ -746,6 +745,7 @@ type text_attr =
     | core_attr
     | graphical_event_attr
     | presentation_attr
+    | `Class
     | `Transform
     | `LengthAdjust
     | `X_list
@@ -779,6 +779,7 @@ type tspan_attr =
     | conditional_processing_attr
     | graphical_event_attr
     | presentation_attr
+    | `Alignment_Baseline
     | `Class
     | `Style
     | `ExternalResourcesRequired
@@ -805,6 +806,7 @@ type tref_attr =
     | graphical_event_attr
     | presentation_attr
     | xlink_attr
+    | `Alignment_Baseline
     | `Class
     | `Style
     | `ExternalResourcesRequired
@@ -834,6 +836,7 @@ type textpath_attr =
     | graphical_event_attr
     | presentation_attr
     | xlink_attr
+    | `Alignment_Baseline
     | `Class
     | `Style
     | `ExternalResourcesRequired
@@ -855,6 +858,7 @@ type altglyph_attr =
     | graphical_event_attr
     | presentation_attr
     | xlink_attr
+    | `Alignment_Baseline
     | `Class
     | `Style
     | `ExternalResourcesRequired

--- a/lib/svg_types.mli
+++ b/lib/svg_types.mli
@@ -162,6 +162,7 @@ type animation_addition_attr = [ | `Additive | `Accumulate ]
 
 type presentation_attr =
   [
+    | `Alignment_Baseline
     | `Baseline_Shift
     | `Clip
     | `Clip_Path
@@ -779,7 +780,6 @@ type tspan_attr =
     | conditional_processing_attr
     | graphical_event_attr
     | presentation_attr
-    | `Alignment_Baseline
     | `Class
     | `Style
     | `ExternalResourcesRequired
@@ -806,7 +806,6 @@ type tref_attr =
     | graphical_event_attr
     | presentation_attr
     | xlink_attr
-    | `Alignment_Baseline
     | `Class
     | `Style
     | `ExternalResourcesRequired
@@ -836,7 +835,6 @@ type textpath_attr =
     | graphical_event_attr
     | presentation_attr
     | xlink_attr
-    | `Alignment_Baseline
     | `Class
     | `Style
     | `ExternalResourcesRequired
@@ -858,7 +856,6 @@ type altglyph_attr =
     | graphical_event_attr
     | presentation_attr
     | xlink_attr
-    | `Alignment_Baseline
     | `Class
     | `Style
     | `ExternalResourcesRequired

--- a/syntax/pa_tyxml.ml
+++ b/syntax/pa_tyxml.ml
@@ -160,7 +160,7 @@ module ParserSvg = Xhtmlparser.Make(Syntax)(struct
   value make_attrib_type _loc tag =
     let tag = match String.lowercase tag with
     [ "accent-height" -> "AccentHeight"
-    | "alignement-baseline" -> "Alignement_Baseline"
+    | "alignment-baseline" -> "Alignment_Baseline"
     | "altglyph" -> "AltGlyph"
     | "animatecolor" -> "AnimateColor"
     | "arabic-form" -> "ArabicForm"


### PR DESCRIPTION
Both `alignment-baseline` and `dominant-baseline` are part of the SVG 1.1 standard:

http://www.w3.org/TR/SVG11/text.html#AlignmentBaselineProperty
http://www.w3.org/TR/SVG11/text.html#DominantBaselineProperty

The `text` element is clearly also part of the standard, and it does accept the `class` attribute:

http://www.w3.org/TR/SVG11/text.html#TextElement