### PR TITLE
Functorial interface updated to support shared reactive Eliom

### DIFF
--- a/doc/manual-wiki/functors.wiki
+++ b/doc/manual-wiki/functors.wiki
@@ -1,47 +1,112 @@
 = The functorial interface =
 
-TyXML provides a functorial interface to implement HTML and SVG on top of any XML implementations. This is used heavily by Eliom to implement the ##F## and ##D## modules, providing respectivelly a functionnal and a DOM version of the HTML implementation.
+TyXML provides a functorial interface to implement HTML and SVG on top
+of any XML implementation. This is used heavily by Eliom to implement
+the ##F## and ##D## modules, providing respectively a functional and
+a DOM version of the HTML implementation.
 
 
 ==@@id="make"@@ The ##Make## functors ==
 
-Those interfaces are available in the modules <<a_api | module Html5_f >> and <<a_api | module Svg_f >>. They provide a functor ##Make## which takes a concrete implementation of Xml following <<a_api | module Xml_sigs.T >>. A default implementation is provided by the <<a_api | module Xml >> module.
-The functor <<a_api | module Html5_f.Make >> also needs an Svg implementation that you can obtain, for example, with the functor <<a_api | module Svg_f.Make >>.
-Due to typing constraints (see next section), The ##Xml## implementation will always need to provide a {{{wrap}}} type answering this definition:
-<<code language="ocaml"| type 'a wrap = 'a >>
+These interfaces are available in the modules
+<<a_api | module Html5_f >> and <<a_api | module Svg_f >>.
+They provide a functor ##Make## which takes a concrete implementation
+of Xml following <<a_api | module Xml_sigs.T >>. A default
+implementation is provided by the <<a_api | module Xml >> module.  The
+functor <<a_api | module Html5_f.Make >> also needs an Svg
+implementation that one can obtain, for example, with the functor
+<<a_api | module Svg_f.Make >>.  The ##Xml## always needs to provide a
+module ##W## of type <<a_api | module Xml_wrap.T >>, along with types
+<<code language="ocaml"| type 'a wrap = 'a W.t >> and
+<<code language="ocaml"| type 'a list_wrap = 'a W.tlist >>.
+The purpose of the ##Wrap## module is explained in the next section.
 
 
 ==@@id="wrap"@@ Wrapping up the nodes ==
 
-Beside the ##Make## functor. those two modules provide a ##MakeWrapped## functor, which allows to wrap Xml elements in a monad.
-A good example of application is the ##R## modules with reactive nodes in eliom. Here is the simplified signature of the {{{div}}} element:
+The ##W## module in <<a_api | Xml_sigs.T>> allows to wrap Xml elements
+in a monad ##'a t##.  A good example of application is the ##R##
+modules with reactive nodes in Eliom. Here is the simplified signature
+of the {{{div}}} element:
 <<code language="ocaml"|R.div : 'a elt list signal -> div elt>>
+{{{signal}}} will wrap the input of every ##Xml## node and be
+integrated in the resulting node.
 
-{{{signal}}} will wrap the input of every ##Xml## nodes and be integrated in the resulting node.
+The ##W## module needs to implement operations over the type of nodes,
+and provides a special type for lists of nodes. The ##W## module
+additionally provides a type ##(-'a, 'b) ft## for (wrapped) functions,
+whose purpose is explained in the next section. In most cases, it is
+sufficient to define:
+<<code language="ocaml"| (-'a, 'b) ft = 'a -> 'b>>
 
-In order to do this, You need to provide an additional ##Wrap## module to the functor, following the signature <<a_api | module Xml_wrap.T >>. This implements operations over the type of nodes along with a special type for lists of nodes.
-The ##Xml## implementation follow <<a_api | module Xml_sigs.Wrapped >>, which is the same as <<a_api| module Xml_sigs.T >>, but with arbitrary {{{'a wrap}}} type.
+An identity wrapper, <<a_api| module Xml_wrap.NoWrap >>, is
+provided. <<a_api| module Xml_wrap.NoWrap >> can be used to apply the
+functor without wrapping the elements.
 
-An identity wrapper, <<a_api| module Xml_wrap.NoWrap >>, is provided. The ##Make## functor is only ##MakeWrapped## partially applied to ##NoWrap##.
+
+==@@id="wrapped_functions"@@ The ##Make_with_wrapped_functions## functors ==
+
+The ##Make_with_wrapped_functions## functors (available in the modules
+<<a_api | module Html5_f >> and <<a_api | module Svg_f >>) differ from
+the ##Make## functors by requiring an additional argument ##C## (of
+type <<a_api | module Html5_f.Wrapped_functions >> and
+<<a_api | module Svg_f.Wrapped_functions >> respectively).
+
+##C## defines a type ##(-'a, 'b) ft##, and a collection of ##ft##
+values.  For applying the functor, the type constraint
+<<code language="ocaml"| ('a, 'b) Xml.W.ft = ('a, 'b) C.ft>>
+needs to be satisfied. The ##ft## values are wrapped functions that
+the functor uses internally to operate on wrapped elements.
+
+The motivation of providing the ##Make_with_wrapped_functions## is as
+follows. Certain monads <<a_api | Xml_sigs.T.t >> can only be operated
+upon by wrapped functions, and not by plain OCaml functions. The
+wrapped functions cannot be produced internally by TyXML, and thus
+have to be provided to the functor. Our intended application is with
+Eliom shared (i.e., client-server) signals. Such signals can only be
+operated upon with Eliom shared functions.
+
+The ##Make## functors are implemented by applying the
+##Make_with_wrapped_functions## functors with TyXML-provided
+##Wrapped_functions## modules that do not wrap the functions, i.e.,
+with: <<code language="ocaml"|(-'a, 'b) ft = 'a -> 'b>>.
 
 
 ==@@id="sig"@@ Exporting the correct signature ==
 
-In order to help export the correct signature after a functor application, four signature functors are provided: <<a_api| module Svg_sigs.Make >>, <<a_api| module Svg_sigs.MakeWrapped >>, <<a_api| module Html5_sigs.Make >> and <<a_api| module Html5_sigs.MakeWrapped >>.
+In order to help export the correct signature after a functor
+application, two signature functors are provided:
+<<a_api| module Svg_sigs.Make >> and <<a_api| module Html5_sigs.Make >>.
 
-As an example of use, let us look at the module <<a_api| module Svg.M >>. Here is the definition of the module:
+As an example of use, let us look at the module <<a_api| module Svg.M >>.
+Here is the definition of the module:
 <<code language="ocaml"|module M = Svg_f.Make(Xml)>>
-In this case, the declaration in the interface file should look like this:
-<<code language="ocaml"|module M : Svg_sigs.Make(Xml).T>>
+In this case, the declaration in the interface file should look like
+this: <<code language="ocaml"|module M : Svg_sigs.Make(Xml).T>>
 
-The signature functor <<a_api| module Svg_sigs.Make >> contains only a signature ##T##, which is equal to <<a_api| module Svg_sigs.T >>, but export various equalities with the module ##Xml##.
+The signature functor <<a_api| module Svg_sigs.Make >> contains only a
+signature ##T##, which is equal to <<a_api| module Svg_sigs.T >>, but
+exports various equalities with the module ##Xml##.
 
-You should **always** use a signature functor to give the type of a module produced by a functor application. It will ensure that exactly the right type equalities are exported and will naturally keep track of changes in tyxml.
+You should **always** use a signature functor to give the type of a
+module produced by a functor application. It will ensure that exactly
+the right type equalities are exported and will naturally keep track
+of changes in TyXML.
 
 There are some important notes about theses signature functors:
-* {{{module M : Svg_sigs.Make(Xml).T}}} doesn't mean that {{{M.Xml}}} is a submodule of {{{Xml}}}. It only means that the types {{{uri}}}, {{{event_handler}}}, {{{mouse_event_handler}}}, {{{keyboard_event_handler}}}, {{{attrib}}} and {{{elt}}} are the same in both modules.
-In the same manner, <<a_api | module Svg_sigs.MakeWrapped>> doesn't force the {{{wrap}}} type to be consistent between ##W## and ##Xml## (as opposed to <<a_api | module Svg_f.MakeWrapped>>) and will just use the types from ##W##.
-This is useful when not exporting the exact module that was used in the functor, but another (smaller and simpler) module. This is the case in <<a_api| module Tyxml_js.R >>, for example.
+* {{{module M : Svg_sigs.Make(Xml).T}}} doesn't mean that {{{M.Xml}}}
+  is a submodule of {{{Xml}}}. It only means that the types {{{uri}}},
+  {{{event_handler}}}, {{{mouse_event_handler}}},
+  {{{keyboard_event_handler}}}, {{{attrib}}} and {{{elt}}} are the
+  same in both modules.  This is useful when not exporting the exact
+  module that was used in the functor, but another (smaller and
+  simpler) module. This is the case in <<a_api| module Tyxml_js.R >>,
+  for example.
 
-* <<a_api | module Html5_f >> and <<a_api | module Svg_f >> functors export two additional equalities, {{{+'a elt = Xml.elt}}} and {{{+'a attrib = Xml.attrib}}}. These equalities **should never be exported in a public interface**. Exporting them would break html typing by allowing to build invalid html trees.
-These equalities are useful internally, for example in eliom they are used to make {{{F.elt}}}, {{{D.elt}}} and {{{R.elt}}} equals.
+* <<a_api | module Html5_f >> and <<a_api | module Svg_f >> functors
+  export two additional equalities, {{{+'a elt = Xml.elt}}} and
+  {{{+'a attrib = Xml.attrib}}}. These equalities **should never be
+  exported in a public interface**. Exporting them would break HTML
+  typing by allowing to build invalid HTML trees.  These equalities
+  are useful internally, for example in Eliom they are used to make
+  {{{F.elt}}}, {{{D.elt}}} and {{{R.elt}}} equals.

--- a/doc/manual-wiki/functors.wiki
+++ b/doc/manual-wiki/functors.wiki
@@ -59,12 +59,12 @@ needs to be satisfied. The ##ft## values are wrapped functions that
 the functor uses internally to operate on wrapped elements.
 
 The motivation of providing the ##Make_with_wrapped_functions## is as
-follows. Certain monads ##('a, 'b) ft## can only be operated upon by
-wrapped functions, and not by plain OCaml functions. The wrapped
-functions cannot be produced internally by TyXML, and thus have to be
-provided to the functor. Our intended application is with Eliom shared
-(i.e., client-server) signals. Such signals can only be operated upon
-with Eliom shared functions.
+follows. Certain monads ##'a t## can only be operated upon by wrapped
+functions, and not by plain OCaml functions. The wrapped functions
+cannot be produced internally by TyXML, and thus have to be provided
+to the functor. Our intended application is with Eliom shared (i.e.,
+client-server) signals. Such signals can only be operated upon with
+Eliom shared functions.
 
 The ##Make## functors are implemented by applying the
 ##Make_with_wrapped_functions## functors with TyXML-provided

--- a/doc/manual-wiki/functors.wiki
+++ b/doc/manual-wiki/functors.wiki
@@ -28,8 +28,8 @@ The ##W## module in <<a_api | Xml_sigs.T>> allows to wrap Xml elements
 in a monad ##'a t##.  A good example of application is the ##R##
 modules with reactive nodes in Eliom. Here is the simplified signature
 of the {{{div}}} element:
-<<code language="ocaml"|R.div : 'a elt list signal -> div elt>>
-{{{signal}}} will wrap the input of every ##Xml## node and be
+<<code language="ocaml"|R.div : 'a elt list t -> div elt>>
+{{{t}}} will wrap the input of every ##Xml## node and be
 integrated in the resulting node.
 
 The ##W## module needs to implement operations over the type of nodes,
@@ -59,12 +59,12 @@ needs to be satisfied. The ##ft## values are wrapped functions that
 the functor uses internally to operate on wrapped elements.
 
 The motivation of providing the ##Make_with_wrapped_functions## is as
-follows. Certain monads <<a_api | Xml_sigs.T.t >> can only be operated
-upon by wrapped functions, and not by plain OCaml functions. The
-wrapped functions cannot be produced internally by TyXML, and thus
-have to be provided to the functor. Our intended application is with
-Eliom shared (i.e., client-server) signals. Such signals can only be
-operated upon with Eliom shared functions.
+follows. Certain monads ##('a, 'b) ft## can only be operated upon by
+wrapped functions, and not by plain OCaml functions. The wrapped
+functions cannot be produced internally by TyXML, and thus have to be
+provided to the functor. Our intended application is with Eliom shared
+(i.e., client-server) signals. Such signals can only be operated upon
+with Eliom shared functions.
 
 The ##Make## functors are implemented by applying the
 ##Make_with_wrapped_functions## functors with TyXML-provided

--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -32,10 +32,11 @@
 
 open Html5_types
 
-module Make'
+module Make_with_wrapped_functions
 
     (Xml : Xml_sigs.T)
-    (C : Html5_sigs.Conv with type ('a, 'b) ft = ('a, 'b) Xml.W.ft)
+    (C : Html5_sigs.Wrapped_functions
+     with type ('a, 'b) ft = ('a, 'b) Xml.W.ft)
     (Svg : Svg_sigs.T with module Xml := Xml) =
 
 struct
@@ -833,7 +834,7 @@ struct
 
 end
 
-module Conv = struct
+module Wrapped_functions = struct
 
   type ('a, 'b) ft = 'a -> 'b
 
@@ -1049,4 +1050,4 @@ end
 module Make
     (Xml : Xml_sigs.T with type ('a, 'b) W.ft = 'a -> 'b)
     (Svg : Svg_sigs.T with module Xml := Xml) =
-  Make'(Xml)(Conv)(Svg)
+  Make_with_wrapped_functions(Xml)(Wrapped_functions)(Svg)

--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -32,9 +32,12 @@
 
 open Html5_types
 
-module Make'_NoSVG
+module Make'
+
     (Xml : Xml_sigs.T)
-    (C : Html5_sigs.Conv with type ('a, 'b) ft = ('a, 'b) Xml.W.ft) =
+    (C : Html5_sigs.Conv with type ('a, 'b) ft = ('a, 'b) Xml.W.ft)
+    (Svg : Svg_sigs.T with module Xml := Xml) =
+
 struct
 
   module Xml = Xml
@@ -693,6 +696,9 @@ struct
 
   let form = star "form"
 
+  let svg ?(a = []) children =
+    Svg.toelt (Svg.svg ~a children)
+
   let input = terminal "input"
 
   let keygen = terminal "keygen"
@@ -824,28 +830,6 @@ struct
     let comma_sep_attrib = Xml.comma_sep_attrib
 
   end
-
-end
-
-module NoSVG = struct
-
-  module Make'
-      (Xml : Xml_sigs.T)
-      (C : Html5_sigs.Conv
-       with type ('a, 'b) ft = ('a, 'b) Xml.W.ft) =
-    Make'_NoSVG(Xml)(C)
-
-end
-
-module Make'
-    (Xml : Xml_sigs.T)
-    (C : Html5_sigs.Conv with type ('a, 'b) ft = ('a, 'b) Xml.W.ft)
-    (Svg : Svg_sigs.T with module Xml := Xml) = struct
-
-  include Make'_NoSVG(Xml)(C)
-
-  let svg ?(a = []) children =
-    Svg.toelt (Svg.svg ~a children)
 
 end
 

--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -84,10 +84,7 @@ struct
   let bool_attrib = user_attrib C.string_of_bool
 
   (* space-separated *)
-  let length_attrib name x =
-    user_attrib
-      C.string_of_multilength
-      name (x :> [< Html5_types.multilength] W.t)
+  let length_attrib = user_attrib C.string_of_multilength
 
   let multilengths_attrib name x =
     user_attrib C.string_of_multilengths name x
@@ -194,31 +191,15 @@ struct
   (* Other Attributes *)
   let a_version = string_attrib "version"
 
-  let user_attrib_bv :
-    string ->
-    ([< Html5_types.big_variant] as 'a) W.t ->
-    Xml.attrib =
-    fun name (v : 'a W.t) ->
-      let f =
-        (C.string_of_variant :
-           ([< Html5_types.big_variant], string) W.ft :>
-           ('a, string) W.ft)
-      in
-      Xml.string_attrib name (W.fmap f v)
-
   let a_xmlns x =
-    user_attrib C.string_of_variant "xmlns"
-      (x : [< `W3_org_1999_xhtml ] wrap :>
-         [< Html5_types.big_variant] wrap)
+    user_attrib C.string_of_big_variant "xmlns" x
 
   let a_manifest = uri_attrib "manifest"
 
   let a_cite = uri_attrib "cite"
 
   let a_xml_space x =
-    user_attrib C.string_of_variant "xml:space"
-      (x : [< `Default | `Preserve ] wrap :>
-         [< Html5_types.big_variant] wrap)
+    user_attrib C.string_of_big_variant "xml:space" x
 
   let a_accesskey c =
     user_attrib C.string_of_character "accesskey" c
@@ -234,7 +215,7 @@ struct
   let a_hreflang = string_attrib "hreflang"
 
   let a_download file =
-     user_attrib (C.unoption_string) "download" file
+    user_attrib (C.unoption_string) "download" file
 
   let a_rel = linktypes_attrib "rel"
 
@@ -254,9 +235,8 @@ struct
 
   let a_for_list = space_sep_attrib "for"
 
-  let a_selected x =
-    user_attrib C.string_of_variant "selected"
-      (x : [< `Selected ]  wrap :> [< Html5_types.big_variant] wrap)
+  let a_selected =
+    user_attrib C.string_of_big_variant "selected"
 
   let a_text_value = string_attrib "value"
 
@@ -268,53 +248,41 @@ struct
 
   let a_action = uri_attrib "action"
 
-  let a_method x =
-    user_attrib C.string_of_variant "method"
-      (x : [< `Delete | `Get | `Post | `Put ]  wrap :>
-         [< Html5_types.big_variant] wrap)
+  let a_method =
+    user_attrib C.string_of_big_variant "method"
 
   let a_enctype = string_attrib "enctype"
 
-  let a_checked x =
-    user_attrib C.string_of_variant "checked"
-      (x : [< `Checked ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_checked =
+    user_attrib C.string_of_big_variant "checked"
 
-  let a_disabled x =
-    user_attrib C.string_of_variant "disabled"
-      (x : [< `Disabled ]  wrap :> [< Html5_types.big_variant] wrap)
+  let a_disabled =
+    user_attrib C.string_of_big_variant "disabled"
 
-  let a_readonly x =
-    user_attrib C.string_of_variant "readonly"
-      (x : [< `ReadOnly ]  wrap :> [< Html5_types.big_variant] wrap)
+  let a_readonly =
+    user_attrib C.string_of_big_variant "readonly"
 
   let a_maxlength = int_attrib "maxlength"
 
   let a_name = string_attrib "name"
 
-  let a_autocomplete x =
-    user_attrib_bv "autocomplete"
-      (x : [< `Off | `On ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_autocomplete =
+    user_attrib C.string_of_big_variant "autocomplete"
 
-  let a_async x =
-    user_attrib C.string_of_variant "async"
-      (x : [< `Async ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_async =
+    user_attrib C.string_of_big_variant "async"
 
-  let a_autofocus x =
-    user_attrib C.string_of_variant "autofocus"
-      (x : [< `Autofocus ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_autofocus =
+    user_attrib C.string_of_big_variant "autofocus"
 
-  let a_autoplay x =
-    user_attrib C.string_of_variant "autoplay"
-      (x : [< `Autoplay ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_autoplay =
+    user_attrib C.string_of_big_variant "autoplay"
 
-  let a_muted x =
-    user_attrib C.string_of_variant "muted"
-      (x : [< `Muted ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_muted =
+    user_attrib C.string_of_big_variant "muted"
 
-  let a_crossorigin x =
-    user_attrib C.string_of_variant "crossorigin"
-      (x : [< `Anonymous | `Use_credentials ] wrap :>
-         [< Html5_types.big_variant] wrap)
+  let a_crossorigin =
+    user_attrib C.string_of_big_variant "crossorigin"
 
   let a_mediagroup = string_attrib "mediagroup"
 
@@ -325,13 +293,11 @@ struct
 
   let a_contextmenu = string_attrib "contextmenu"
 
-  let a_controls x =
-    user_attrib C.string_of_variant "controls"
-      (x : [< `Controls ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_controls =
+    user_attrib C.string_of_big_variant "controls"
 
-  let a_dir x =
-    user_attrib C.string_of_variant "dir"
-      (x : [< `Ltr | `Rtl ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_dir =
+    user_attrib C.string_of_big_variant "dir"
 
   let a_draggable d =
     bool_attrib "draggable" d
@@ -344,33 +310,27 @@ struct
 
   let a_formmethod = a_method
 
-  let a_formnovalidate x =
-    user_attrib C.string_of_variant "formnovalidate"
-      (x : [< `Formnovalidate ] wrap :>
-         [< Html5_types.big_variant] wrap)
+  let a_formnovalidate =
+    user_attrib C.string_of_big_variant "formnovalidate"
 
   let a_formtarget = string_attrib "formtarget"
 
-  let a_hidden x =
-    user_attrib C.string_of_variant "hidden"
-      (x : [< `Hidden ] wrap :>
-         [< Html5_types.big_variant] wrap)
+  let a_hidden =
+    user_attrib C.string_of_big_variant "hidden"
 
   let a_high = float_attrib "high"
 
   let a_icon = uri_attrib "icon"
 
-  let a_ismap x =
-    user_attrib C.string_of_variant "ismap"
-      (x : [< `Ismap ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_ismap =
+    user_attrib C.string_of_big_variant "ismap"
 
   let a_keytype = string_attrib "keytype"
 
   let a_list = string_attrib "list"
 
-  let a_loop x =
-    user_attrib C.string_of_variant "loop"
-      (x : [< `Loop ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_loop =
+    user_attrib C.string_of_big_variant "loop"
 
   let a_low = float_attrib "low"
 
@@ -382,13 +342,11 @@ struct
 
   let a_input_min = float_attrib "min"
 
-  let a_novalidate x =
-    user_attrib C.string_of_variant "novalidate"
-      (x : [< `Novalidate ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_novalidate =
+    user_attrib C.string_of_big_variant "novalidate"
 
-  let a_open x =
-    user_attrib C.string_of_variant "open"
-      (x : [< `Open ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_open =
+    user_attrib C.string_of_big_variant "open"
 
   let a_optimum = float_attrib "optimum"
 
@@ -398,24 +356,19 @@ struct
 
   let a_poster = uri_attrib "poster"
 
-  let a_preload x =
-    user_attrib C.string_of_variant "preload"
-      (x : [< `Audio | `Metadata | `None ] wrap :>
-         [< Html5_types.big_variant] wrap)
+  let a_preload =
+    user_attrib C.string_of_big_variant "preload"
 
-  let a_pubdate x =
-    user_attrib C.string_of_variant "pubdate"
-      (x : [< `Pubdate ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_pubdate =
+    user_attrib C.string_of_big_variant "pubdate"
 
   let a_radiogroup = string_attrib "radiogroup"
 
-  let a_required x =
-    user_attrib C.string_of_variant "required"
-      (x : [< `Required ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_required =
+    user_attrib C.string_of_big_variant "required"
 
-  let a_reversed x =
-    user_attrib C.string_of_variant "reserved"
-      (x : [< `Reversed ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_reversed =
+    user_attrib C.string_of_big_variant "reserved"
 
   let a_sandbox x =
     user_attrib C.string_of_sandbox "sandbox" x
@@ -423,13 +376,11 @@ struct
   let a_spellcheck sc =
     bool_attrib "spellcheck" sc
 
-  let a_scoped x =
-    user_attrib C.string_of_variant "scoped"
-      (x : [< `Scoped ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_scoped =
+    user_attrib C.string_of_big_variant "scoped"
 
-  let a_seamless x =
-    user_attrib C.string_of_variant "seamless"
-      (x : [< `Seamless ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_seamless =
+    user_attrib C.string_of_big_variant "seamless"
 
   let a_sizes sizes =
     user_attrib C.string_of_sizes "sizes" sizes
@@ -444,31 +395,25 @@ struct
   let a_step step =
     user_attrib C.string_of_step "step" step
 
-  let a_wrap x =
-    user_attrib C.string_of_variant "wrap"
-      (x : [< `Hard | `Soft ] wrap :> [< Html5_types.big_variant] wrap)
+  let a_wrap =
+    user_attrib C.string_of_big_variant "wrap"
 
   let a_size = int_attrib "size"
 
   let a_input_type it =
     user_attrib C.string_of_input_type "type" it
 
-  let a_menu_type x =
-    user_attrib C.string_of_variant "type"
-      (x : [< `Context | `Toolbar] wrap :>
-         [< Html5_types.big_variant] wrap)
+  let a_menu_type =
+    user_attrib C.string_of_big_variant "type"
 
-  let a_command_type x =
-    user_attrib C.string_of_variant "type"
-      (x : [< `Checkbox | `Command | `Radio ]  wrap :>
-         [< Html5_types.big_variant] wrap)
+  let a_command_type =
+    user_attrib C.string_of_big_variant "type"
 
   let a_button_type bt =
     user_attrib C.string_of_input_type "type" bt
 
-  let a_multiple x =
-    user_attrib C.string_of_variant "multiple"
-      (x : [< `Multiple ]  wrap :> [< Html5_types.big_variant] wrap)
+  let a_multiple =
+    user_attrib C.string_of_big_variant "multiple"
 
   let a_cols = int_attrib "cols"
 
@@ -476,10 +421,8 @@ struct
 
   let a_summary = string_attrib "summary"
 
-  let a_align x =
-    user_attrib C.string_of_variant "align"
-      (x : [< `Char | `Justify | `Left | `Right ]  wrap :>
-         [< Html5_types.big_variant] wrap)
+  let a_align =
+    user_attrib C.string_of_big_variant "align"
 
   let a_axis = string_attrib "axis"
 
@@ -489,24 +432,19 @@ struct
 
   let a_rowspan = int_attrib "rowspan"
 
-  let a_scope x =
-    user_attrib C.string_of_variant "scope"
-      (x : [< `Col | `Colgroup | `Row | `Rowgroup ]  wrap :>
-         [< Html5_types.big_variant] wrap)
+  let a_scope =
+    user_attrib C.string_of_big_variant "scope"
 
   let a_border = int_attrib "border"
 
-  let a_cellpadding (x : Html5_types.length W.t) =
-    length_attrib "cellpadding" x
+  let a_cellpadding = length_attrib "cellpadding"
 
   let a_cellspacing = length_attrib "cellspacing"
 
   let a_datapagesize = string_attrib "datapagesize"
 
-  let a_rules x =
-    user_attrib C.string_of_variant "rules"
-      (x : [< `All | `Cols | `Groups | `None | `Rows ] wrap :>
-         [< Html5_types.big_variant] wrap)
+  let a_rules =
+    user_attrib C.string_of_big_variant "rules"
 
   let a_char c =
     user_attrib C.string_of_character "char" c
@@ -521,19 +459,15 @@ struct
 
   let a_fs_cols mls = multilengths_attrib "cols" mls
 
-  let a_frameborder x =
-    user_attrib C.string_of_variant "frameborder"
-      (x : [< `One | `Zero ]  wrap :>
-         [< Html5_types.big_variant] wrap)
+  let a_frameborder =
+    user_attrib C.string_of_big_variant "frameborder"
 
   let a_marginheight = int_attrib "marginheight"
 
   let a_marginwidth = int_attrib "marginwidth"
 
-  let a_scrolling x =
-    user_attrib C.string_of_variant "scrolling"
-      (x : [< `Auto | `No | `Yes ]  wrap :>
-         [< Html5_types.big_variant] wrap)
+  let a_scrolling =
+    user_attrib C.string_of_big_variant "scrolling"
 
   let a_target = string_attrib "target"
 
@@ -694,18 +628,16 @@ struct
 
   let a_datetime = string_attrib "datetime"
 
-  let a_shape x =
-    user_attrib C.string_of_variant "shape"
-      (x : [< shape] W.t :> [< Html5_types.big_variant] W.t)
+  let a_shape =
+    user_attrib C.string_of_big_variant "shape"
 
   let a_coords coords =
     user_attrib C.string_of_numbers "coords" coords
 
   let a_usemap = string_attrib "usemap"
 
-  let a_defer x =
-    user_attrib C.string_of_variant "defer"
-      (x : [< `Defer ]  wrap :> [< Html5_types.big_variant] W.t)
+  let a_defer =
+    user_attrib C.string_of_big_variant "defer"
 
   let a_label = string_attrib "label"
 
@@ -975,7 +907,7 @@ module Conv = struct
     | `TV -> "tv"
     | `Raw_mediadesc s -> s
 
-  let string_of_variant = function
+  let string_of_big_variant = function
     | `Anonymous -> "anonymous"
     | `Async -> "async"
     | `Autofocus -> "autofocus"
@@ -1092,7 +1024,7 @@ module Conv = struct
     | `Url -> "url"
     | `Week -> "week"
 
-  let string_of_character _ = ""
+  let string_of_character = String.make 1
 
   let string_of_number = string_of_int
 
@@ -1131,12 +1063,6 @@ module Conv = struct
 end
 
 module Make
-
     (Xml : Xml_sigs.T with type ('a, 'b) W.ft = 'a -> 'b)
     (Svg : Svg_sigs.T with module Xml := Xml) =
-
-struct
-
-  include Make'(Xml)(Conv)(Svg)
-
-end
+  Make'(Xml)(Conv)(Svg)

--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -238,8 +238,8 @@ struct
 
   let a_for_list = space_sep_attrib "for"
 
-  let a_selected =
-    user_attrib C.string_of_big_variant "selected"
+  let a_selected x =
+    user_attrib C.string_of_big_variant "selected" x
 
   let a_text_value = string_attrib "value"
 
@@ -251,41 +251,41 @@ struct
 
   let a_action = uri_attrib "action"
 
-  let a_method =
-    user_attrib C.string_of_big_variant "method"
+  let a_method x =
+    user_attrib C.string_of_big_variant "method" x
 
   let a_enctype = string_attrib "enctype"
 
-  let a_checked =
-    user_attrib C.string_of_big_variant "checked"
+  let a_checked x =
+    user_attrib C.string_of_big_variant "checked" x
 
-  let a_disabled =
-    user_attrib C.string_of_big_variant "disabled"
+  let a_disabled x =
+    user_attrib C.string_of_big_variant "disabled" x
 
-  let a_readonly =
-    user_attrib C.string_of_big_variant "readonly"
+  let a_readonly x =
+    user_attrib C.string_of_big_variant "readonly" x
 
   let a_maxlength = int_attrib "maxlength"
 
   let a_name = string_attrib "name"
 
-  let a_autocomplete =
-    user_attrib C.string_of_big_variant "autocomplete"
+  let a_autocomplete x =
+    user_attrib C.string_of_big_variant "autocomplete" x
 
-  let a_async =
-    user_attrib C.string_of_big_variant "async"
+  let a_async x =
+    user_attrib C.string_of_big_variant "async" x
 
-  let a_autofocus =
-    user_attrib C.string_of_big_variant "autofocus"
+  let a_autofocus x =
+    user_attrib C.string_of_big_variant "autofocus" x
 
-  let a_autoplay =
-    user_attrib C.string_of_big_variant "autoplay"
+  let a_autoplay x =
+    user_attrib C.string_of_big_variant "autoplay" x
 
-  let a_muted =
-    user_attrib C.string_of_big_variant "muted"
+  let a_muted x =
+    user_attrib C.string_of_big_variant "muted" x
 
-  let a_crossorigin =
-    user_attrib C.string_of_big_variant "crossorigin"
+  let a_crossorigin x =
+    user_attrib C.string_of_big_variant "crossorigin" x
 
   let a_mediagroup = string_attrib "mediagroup"
 
@@ -296,11 +296,11 @@ struct
 
   let a_contextmenu = string_attrib "contextmenu"
 
-  let a_controls =
-    user_attrib C.string_of_big_variant "controls"
+  let a_controls x =
+    user_attrib C.string_of_big_variant "controls" x
 
-  let a_dir =
-    user_attrib C.string_of_big_variant "dir"
+  let a_dir x =
+    user_attrib C.string_of_big_variant "dir" x
 
   let a_draggable d =
     bool_attrib "draggable" d
@@ -313,27 +313,27 @@ struct
 
   let a_formmethod = a_method
 
-  let a_formnovalidate =
-    user_attrib C.string_of_big_variant "formnovalidate"
+  let a_formnovalidate x =
+    user_attrib C.string_of_big_variant "formnovalidate" x
 
   let a_formtarget = string_attrib "formtarget"
 
-  let a_hidden =
-    user_attrib C.string_of_big_variant "hidden"
+  let a_hidden x =
+    user_attrib C.string_of_big_variant "hidden" x
 
   let a_high = float_attrib "high"
 
   let a_icon = uri_attrib "icon"
 
-  let a_ismap =
-    user_attrib C.string_of_big_variant "ismap"
+  let a_ismap x =
+    user_attrib C.string_of_big_variant "ismap" x
 
   let a_keytype = string_attrib "keytype"
 
   let a_list = string_attrib "list"
 
-  let a_loop =
-    user_attrib C.string_of_big_variant "loop"
+  let a_loop x =
+    user_attrib C.string_of_big_variant "loop" x
 
   let a_low = float_attrib "low"
 
@@ -345,11 +345,11 @@ struct
 
   let a_input_min = float_attrib "min"
 
-  let a_novalidate =
-    user_attrib C.string_of_big_variant "novalidate"
+  let a_novalidate x =
+    user_attrib C.string_of_big_variant "novalidate" x
 
-  let a_open =
-    user_attrib C.string_of_big_variant "open"
+  let a_open x =
+    user_attrib C.string_of_big_variant "open" x
 
   let a_optimum = float_attrib "optimum"
 
@@ -359,19 +359,19 @@ struct
 
   let a_poster = uri_attrib "poster"
 
-  let a_preload =
-    user_attrib C.string_of_big_variant "preload"
+  let a_preload x =
+    user_attrib C.string_of_big_variant "preload" x
 
-  let a_pubdate =
-    user_attrib C.string_of_big_variant "pubdate"
+  let a_pubdate x =
+    user_attrib C.string_of_big_variant "pubdate" x
 
   let a_radiogroup = string_attrib "radiogroup"
 
-  let a_required =
-    user_attrib C.string_of_big_variant "required"
+  let a_required x =
+    user_attrib C.string_of_big_variant "required" x
 
-  let a_reversed =
-    user_attrib C.string_of_big_variant "reserved"
+  let a_reversed x =
+    user_attrib C.string_of_big_variant "reserved" x
 
   let a_sandbox x =
     user_attrib C.string_of_sandbox "sandbox" x
@@ -379,11 +379,11 @@ struct
   let a_spellcheck sc =
     bool_attrib "spellcheck" sc
 
-  let a_scoped =
-    user_attrib C.string_of_big_variant "scoped"
+  let a_scoped x =
+    user_attrib C.string_of_big_variant "scoped" x
 
-  let a_seamless =
-    user_attrib C.string_of_big_variant "seamless"
+  let a_seamless x =
+    user_attrib C.string_of_big_variant "seamless" x
 
   let a_sizes sizes =
     user_attrib C.string_of_sizes "sizes" sizes
@@ -398,25 +398,25 @@ struct
   let a_step step =
     user_attrib C.string_of_step "step" step
 
-  let a_wrap =
-    user_attrib C.string_of_big_variant "wrap"
+  let a_wrap x =
+    user_attrib C.string_of_big_variant "wrap" x
 
   let a_size = int_attrib "size"
 
   let a_input_type it =
     user_attrib C.string_of_input_type "type" it
 
-  let a_menu_type =
-    user_attrib C.string_of_big_variant "type"
+  let a_menu_type x =
+    user_attrib C.string_of_big_variant "type" x
 
-  let a_command_type =
-    user_attrib C.string_of_big_variant "type"
+  let a_command_type x =
+    user_attrib C.string_of_big_variant "type" x
 
   let a_button_type bt =
     user_attrib C.string_of_input_type "type" bt
 
-  let a_multiple =
-    user_attrib C.string_of_big_variant "multiple"
+  let a_multiple x =
+    user_attrib C.string_of_big_variant "multiple" x
 
   let a_cols = int_attrib "cols"
 
@@ -424,8 +424,8 @@ struct
 
   let a_summary = string_attrib "summary"
 
-  let a_align =
-    user_attrib C.string_of_big_variant "align"
+  let a_align x =
+    user_attrib C.string_of_big_variant "align" x
 
   let a_axis = string_attrib "axis"
 
@@ -435,8 +435,8 @@ struct
 
   let a_rowspan = int_attrib "rowspan"
 
-  let a_scope =
-    user_attrib C.string_of_big_variant "scope"
+  let a_scope x =
+    user_attrib C.string_of_big_variant "scope" x
 
   let a_border = int_attrib "border"
 
@@ -446,8 +446,8 @@ struct
 
   let a_datapagesize = string_attrib "datapagesize"
 
-  let a_rules =
-    user_attrib C.string_of_big_variant "rules"
+  let a_rules x =
+    user_attrib C.string_of_big_variant "rules" x
 
   let a_char c =
     user_attrib C.string_of_character "char" c
@@ -462,15 +462,15 @@ struct
 
   let a_fs_cols mls = multilengths_attrib "cols" mls
 
-  let a_frameborder =
-    user_attrib C.string_of_big_variant "frameborder"
+  let a_frameborder x =
+    user_attrib C.string_of_big_variant "frameborder" x
 
   let a_marginheight = int_attrib "marginheight"
 
   let a_marginwidth = int_attrib "marginwidth"
 
-  let a_scrolling =
-    user_attrib C.string_of_big_variant "scrolling"
+  let a_scrolling x =
+    user_attrib C.string_of_big_variant "scrolling" x
 
   let a_target = string_attrib "target"
 
@@ -631,16 +631,16 @@ struct
 
   let a_datetime = string_attrib "datetime"
 
-  let a_shape =
-    user_attrib C.string_of_big_variant "shape"
+  let a_shape x =
+    user_attrib C.string_of_big_variant "shape" x
 
   let a_coords coords =
     user_attrib C.string_of_numbers "coords" coords
 
   let a_usemap = string_attrib "usemap"
 
-  let a_defer =
-    user_attrib C.string_of_big_variant "defer"
+  let a_defer x =
+    user_attrib C.string_of_big_variant "defer" x
 
   let a_label = string_attrib "label"
 

--- a/lib/html5_f.mli
+++ b/lib/html5_f.mli
@@ -28,6 +28,8 @@ module Make
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib
 
+module Conv : Html5_sigs.Conv with type (-'a, 'b) ft = 'a -> 'b
+
 module Make'
     (Xml : Xml_sigs.T)
     (Conv : Html5_sigs.Conv with type ('a, 'b) ft = ('a, 'b) Xml.W.ft)

--- a/lib/html5_f.mli
+++ b/lib/html5_f.mli
@@ -37,15 +37,3 @@ module Make'
   : Html5_sigs.Make(Xml)(Svg).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib
-
-module NoSVG : sig
-
-  module Make'
-      (Xml : Xml_sigs.T)
-      (Conv : Html5_sigs.Conv
-       with type ('a, 'b) ft = ('a, 'b) Xml.W.ft)
-    : Html5_sigs.Make_NoSVG(Xml).T
-      with type +'a elt = Xml.elt
-       and type +'a attrib = Xml.attrib
-
-end

--- a/lib/html5_f.mli
+++ b/lib/html5_f.mli
@@ -22,8 +22,28 @@
 (** Typesafe constructors for HTML5 documents (Functorial interface) *)
 
 module Make
-    (Xml : Xml_sigs.T)
+    (Xml : Xml_sigs.T with type ('a, 'b) W.ft = 'a -> 'b)
     (Svg : Svg_sigs.T with module Xml := Xml)
   : Html5_sigs.Make(Xml)(Svg).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib
+
+module Make'
+    (Xml : Xml_sigs.T)
+    (Conv : Html5_sigs.Conv with type ('a, 'b) ft = ('a, 'b) Xml.W.ft)
+    (Svg : Svg_sigs.T with module Xml := Xml)
+  : Html5_sigs.Make(Xml)(Svg).T
+    with type +'a elt = Xml.elt
+     and type +'a attrib = Xml.attrib
+
+module NoSVG : sig
+
+  module Make'
+      (Xml : Xml_sigs.T)
+      (Conv : Html5_sigs.Conv
+       with type ('a, 'b) ft = ('a, 'b) Xml.W.ft)
+    : Html5_sigs.Make_NoSVG(Xml).T
+      with type +'a elt = Xml.elt
+       and type +'a attrib = Xml.attrib
+
+end

--- a/lib/html5_f.mli
+++ b/lib/html5_f.mli
@@ -28,11 +28,13 @@ module Make
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib
 
-module Conv : Html5_sigs.Conv with type (-'a, 'b) ft = 'a -> 'b
+module Wrapped_functions :
+  Html5_sigs.Wrapped_functions with type (-'a, 'b) ft = 'a -> 'b
 
-module Make'
+module Make_with_wrapped_functions
     (Xml : Xml_sigs.T)
-    (Conv : Html5_sigs.Conv with type ('a, 'b) ft = ('a, 'b) Xml.W.ft)
+    (C : Html5_sigs.Wrapped_functions
+     with type ('a, 'b) ft = ('a, 'b) Xml.W.ft)
     (Svg : Svg_sigs.T with module Xml := Xml)
   : Html5_sigs.Make(Xml)(Svg).T
     with type +'a elt = Xml.elt

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -1190,7 +1190,7 @@ end
 
 module type NoWrap = T with module Xml.W = Xml_wrap.NoWrap
 
-module type Conv = sig
+module type Wrapped_functions = sig
 
   type (-'a, 'b) ft
 

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -1200,40 +1200,14 @@ module type NoWrap = T with module Xml.W = Xml_wrap.NoWrap
 
 module type Conv = sig
 
-  type ('a, 'b) ft
+  type (-'a, 'b) ft
 
-    (* In the general case, it is imppossible to transform OCaml
-     functions into [ft] values, e.g., for
-       [('a, 'b) ft = ('a -> 'b) Eliom_lib.shared_value] ,
-     it is impossible to produce the client part of the shared_value
-     by injecting a server-side function. To circumvent this, our
-     functorial interface receives a collection of [ft] values for the
-       operations needed. *)
-
-  val unoption_string : (string option, string) ft
-
-  val string_of_step : (float option, string) ft
+  val string_of_big_variant :
+    ([< Html5_types.big_variant], string) ft
 
   val string_of_bool : (bool, string) ft
 
-  val string_of_number : (Html5_types.number, string) ft
-
   val string_of_character : (Html5_types.character, string) ft
-
-  val string_of_multilength :
-    ([< Html5_types.multilength], string) ft
-
-  val string_of_sandbox_token :
-    ([< Html5_types.sandbox_token], string) ft
-
-  val string_of_linktype :
-    ([< Html5_types.linktype], string) ft
-
-  val string_of_variant :
-    ([< Html5_types.big_variant], string) ft
-
-  val string_of_mediadesc_token :
-    ([< Html5_types.mediadesc_token], string) ft
 
   val string_of_input_type :
     ([< Html5_types.input_type], string) ft
@@ -1244,17 +1218,23 @@ module type Conv = sig
   val string_of_mediadesc :
     ([< Html5_types.mediadesc_token] list, string) ft
 
+  val string_of_multilength :
+    ([< Html5_types.multilength], string) ft
+
   val string_of_multilengths :
     ([< Html5_types.multilength] list, string) ft
 
-  val string_of_sizes :
-    ([< Html5_types.sizes], string) ft
+  val string_of_numbers : (Html5_types.numbers, string) ft
 
   val string_of_sandbox :
     ([< Html5_types.sandbox_token] list, string) ft
 
-  val string_of_numbers :
-    (Html5_types.numbers, string) ft
+  val string_of_sizes :
+    ([< Html5_types.sizes], string) ft
+
+  val string_of_step : (float option, string) ft
+
+  val unoption_string : (string option, string) ft
 
 end
 

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -17,13 +17,11 @@
  * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
 *)
 
-module type T = sig
+module type T_NoSVG = sig
 
   open Html5_types
 
   module Xml : Xml_sigs.T
-
-  module Svg : Svg_sigs.T with module Xml := Xml
 
   module Info : Xml_sigs.Info
 
@@ -561,9 +559,6 @@ module type T = sig
   val title : (title_attrib, [< | title_content_fun], [> | title]) unary
 
   val body : ([< | body_attrib], [< | body_content_fun], [> | body]) star
-
-
-  val svg : ?a : [< svg_attrib ] Svg.attrib list -> [< svg_content ] Svg.elt list_wrap -> [> svg ] elt
 
   (** {2 Section} *)
 
@@ -1188,7 +1183,80 @@ module type T = sig
 
 end
 
+module type T = sig
+
+  include T_NoSVG
+
+  module Svg : Svg_sigs.T with module Xml := Xml
+
+  val svg :
+    ?a : [< Html5_types.svg_attrib ] Svg.attrib list ->
+    [< Html5_types.svg_content ] Svg.elt list_wrap ->
+    [> Html5_types.svg ] elt
+
+end
+
 module type NoWrap = T with module Xml.W = Xml_wrap.NoWrap
+
+module type Conv = sig
+
+  type ('a, 'b) ft
+
+    (* In the general case, it is imppossible to transform OCaml
+     functions into [ft] values, e.g., for
+       [('a, 'b) ft = ('a -> 'b) Eliom_lib.shared_value] ,
+     it is impossible to produce the client part of the shared_value
+     by injecting a server-side function. To circumvent this, our
+     functorial interface receives a collection of [ft] values for the
+       operations needed. *)
+
+  val unoption_string : (string option, string) ft
+
+  val string_of_step : (float option, string) ft
+
+  val string_of_bool : (bool, string) ft
+
+  val string_of_number : (Html5_types.number, string) ft
+
+  val string_of_character : (Html5_types.character, string) ft
+
+  val string_of_multilength :
+    ([< Html5_types.multilength], string) ft
+
+  val string_of_sandbox_token :
+    ([< Html5_types.sandbox_token], string) ft
+
+  val string_of_linktype :
+    ([< Html5_types.linktype], string) ft
+
+  val string_of_variant :
+    ([< Html5_types.big_variant], string) ft
+
+  val string_of_mediadesc_token :
+    ([< Html5_types.mediadesc_token], string) ft
+
+  val string_of_input_type :
+    ([< Html5_types.input_type], string) ft
+
+  val string_of_linktypes :
+    ([< Html5_types.linktype] list, string) ft
+
+  val string_of_mediadesc :
+    ([< Html5_types.mediadesc_token] list, string) ft
+
+  val string_of_multilengths :
+    ([< Html5_types.multilength] list, string) ft
+
+  val string_of_sizes :
+    ([< Html5_types.sizes], string) ft
+
+  val string_of_sandbox :
+    ([< Html5_types.sandbox_token] list, string) ft
+
+  val string_of_numbers :
+    (Html5_types.numbers, string) ft
+
+end
 
 (** {2 Signature functors} *)
 (** See {% <<a_manual chapter="functors"|the manual of the functorial interface>> %}. *)
@@ -1210,4 +1278,20 @@ sig
      and type Xml.attrib = Xml.attrib
      and type Xml.elt = Xml.elt
      and module Svg := Svg
+end
+
+(** Signature functor for {!Html5_f.NoSVG.Make}. *)
+module Make_NoSVG(Xml : Xml_sigs.T): sig
+
+  (** See {!modtype:Html5_sigs.T}. *)
+  module type T = T_NoSVG
+    with type 'a Xml.W.t = 'a Xml.W.t
+     and type 'a Xml.W.tlist = 'a Xml.W.tlist
+     and type Xml.uri = Xml.uri
+     and type Xml.event_handler = Xml.event_handler
+     and type Xml.mouse_event_handler = Xml.mouse_event_handler
+     and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
+     and type Xml.attrib = Xml.attrib
+     and type Xml.elt = Xml.elt
+
 end

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -17,11 +17,13 @@
  * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
 *)
 
-module type T_NoSVG = sig
+module type T = sig
 
   open Html5_types
 
   module Xml : Xml_sigs.T
+
+  module Svg : Svg_sigs.T with module Xml := Xml
 
   module Info : Xml_sigs.Info
 
@@ -559,6 +561,9 @@ module type T_NoSVG = sig
   val title : (title_attrib, [< | title_content_fun], [> | title]) unary
 
   val body : ([< | body_attrib], [< | body_content_fun], [> | body]) star
+
+
+  val svg : ?a : [< svg_attrib ] Svg.attrib list -> [< svg_content ] Svg.elt list_wrap -> [> svg ] elt
 
   (** {2 Section} *)
 
@@ -1183,19 +1188,6 @@ module type T_NoSVG = sig
 
 end
 
-module type T = sig
-
-  include T_NoSVG
-
-  module Svg : Svg_sigs.T with module Xml := Xml
-
-  val svg :
-    ?a : [< Html5_types.svg_attrib ] Svg.attrib list ->
-    [< Html5_types.svg_content ] Svg.elt list_wrap ->
-    [> Html5_types.svg ] elt
-
-end
-
 module type NoWrap = T with module Xml.W = Xml_wrap.NoWrap
 
 module type Conv = sig
@@ -1258,20 +1250,4 @@ sig
      and type Xml.attrib = Xml.attrib
      and type Xml.elt = Xml.elt
      and module Svg := Svg
-end
-
-(** Signature functor for {!Html5_f.NoSVG.Make}. *)
-module Make_NoSVG(Xml : Xml_sigs.T): sig
-
-  (** See {!modtype:Html5_sigs.T}. *)
-  module type T = T_NoSVG
-    with type 'a Xml.W.t = 'a Xml.W.t
-     and type 'a Xml.W.tlist = 'a Xml.W.tlist
-     and type Xml.uri = Xml.uri
-     and type Xml.event_handler = Xml.event_handler
-     and type Xml.mouse_event_handler = Xml.mouse_event_handler
-     and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-     and type Xml.attrib = Xml.attrib
-     and type Xml.elt = Xml.elt
-
 end

--- a/lib/html5_types.mli
+++ b/lib/html5_types.mli
@@ -113,7 +113,7 @@ type length = [ | `Pixels of int | `Percent of int ]
     horizontal or vertical space. Thus, the value [`Percent 50] means half of
     the available space. *)
 
-type linktypes =
+type linktype =
   [
     | `Alternate
     | `Archives
@@ -137,7 +137,9 @@ type linktypes =
     | `Sidebar
     | `Tag
     | `Up
-    | `Other of string ] list
+    | `Other of string ]
+
+type linktypes = linktype list
 (** Authors may use the following recognized link types, listed here with
         their conventional interpretations. A LinkTypes value refers to a
         space-separated list of link types. White space characters are not
@@ -195,20 +197,22 @@ type linktypes =
         Provides a link to a document giving the context for the current document.}
         } *)
 
-type mediadesc =
-  [
-    | `All
-    | `Aural
-    | `Braille
-    | `Embossed
-    | `Handheld
-    | `Print
-    | `Projection
-    | `Screen
-    | `Speech
-    | `TTY
-    | `TV
-    | `Raw_mediadesc of string ] list
+type mediadesc_token =
+  [ `All
+  | `Aural
+  | `Braille
+  | `Embossed
+  | `Handheld
+  | `Print
+  | `Projection
+  | `Screen
+  | `Speech
+  | `TTY
+  | `TV
+  | `Raw_mediadesc of string ]
+
+type mediadesc = mediadesc_token list
+
 (** The MediaDesc attribute is a comma-separated list of media descriptors.
         The following is a list of recognized media descriptors:
         {ul
@@ -2225,3 +2229,111 @@ type link_content_fun = notag
 type link_attrib =
   [ | common | `Hreflang | `Media | `Rel | `Href | `Sizes | `Mime_type
   ]
+
+type big_variant =
+  [ `W3_org_1999_xhtml
+  | `Default
+  | `Preserve
+  | `Selected
+  | `Get
+  | `Post
+  | `Put
+  | `Delete
+  | `Checked
+  | `Disabled
+  | `ReadOnly
+  | `On
+  | `Off
+  | `Async
+  | `Autofocus
+  | `Autoplay
+  | `Muted
+  | `Anonymous
+  | `Use_credentials
+  | `Controls
+  | `Ltr
+  | `Rtl
+  | `Formnovalidate
+  | `Hidden
+  | `Ismap
+  | `Loop
+  | `Novalidate
+  | `Open
+  | `Audio
+  | `Metadata
+  | `None
+  | `Pubdate
+  | `Required
+  | `Reversed
+  | `Scoped
+  | `Seamless
+  | `Hard
+  | `Soft
+  | `Multiple
+  | `Checkbox
+  | `Command
+  | `Radio
+  | `Context
+  | `Toolbar
+  | `Char
+  | `Justify
+  | `Left
+  | `Right
+  | `Col
+  | `Colgroup
+  | `Row
+  | `Rowgroup
+  | `All
+  | `Cols
+  | `Groups
+  | `None
+  | `Rows
+  | `Rect
+  | `Circle
+  | `Poly
+  | `Default
+  | `One
+  | `Zero
+  | `Auto
+  | `No
+  | `Yes
+  | `Defer
+  ]
+
+type sandbox_token =
+  [ `AllowForms
+  | `AllowPointerLock
+  | `AllowPopups
+  | `AllowTopNavigation
+  | `AllowSameOrigin
+  | `AllowScript ]
+
+
+type input_type =
+  [ `Button
+  | `Checkbox
+  | `Color
+  | `Date
+  | `Datetime
+  | `Datetime_local
+  | `Email
+  | `File
+  | `Hidden
+  | `Image
+  | `Month
+  | `Number
+  | `Password
+  | `Radio
+  | `Range
+  | `Reset
+  | `Search
+  | `Submit
+  | `Tel
+  | `Text
+  | `Time
+  | `Url
+  | `Week ]
+
+type sizes =
+  [ `Sizes of (number * number) list
+  | `Any ]

--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -86,38 +86,7 @@ let opt_concat ?(sep=" ") s f = function
 let list ?(sep=" ") f l = String.concat sep (List.map f l)
 let comma_list = list ~sep:", "
 
-let string_of_coord = string_of_length
-let string_of_number = string_of_float
-let string_of_number_optional_number =
-  function
-  | (x, Some y) -> Printf.sprintf "%g, %g" x y
-  | (x, None) -> Printf.sprintf "%g" x
 let string_of_percentage = Printf.sprintf "%d%%"
-
-
-let string_of_transform =
-  function
-  | Matrix ((a, b, c, d, e, f)) ->
-    Printf.sprintf "matrix(%g %g %g %g %g %g)" a b c d e f
-  | Translate x ->
-    Printf.sprintf "translate(%s)" (string_of_number_optional_number x)
-  | Scale x ->
-    Printf.sprintf "scale(%s)" (string_of_number_optional_number x)
-  | Rotate ((angle, x)) ->
-    Printf.sprintf "rotate(%s %s)" (string_of_angle angle)
-      (match x with
-       | Some ((x, y)) -> Printf.sprintf "%g %g" x y
-       | None -> "")
-  | SkewX angle -> Printf.sprintf "skewX(%s)" (string_of_angle angle)
-  | SkewY angle -> Printf.sprintf "skewY(%s)" (string_of_angle angle)
-let string_of_transforms x = String.concat " " (List.map string_of_transform x)
-let string_of_fourfloats (a, b, c, d) = Printf.sprintf "%g %g %g %g" a b c d
-
-let string_of_lengths = list string_of_length
-let string_of_numbers = list string_of_float
-let string_of_numbers_semicolon = list ~sep:"; " string_of_float
-
-let string_of_coords = list (fun (a, b) -> Printf.sprintf "%g, %g" a b)
 
 let string_of_color s = s
 (* For now just string, we may want something better in the future. *)
@@ -135,7 +104,11 @@ let string_of_paint = function
     (string_of_iri iri) ^" "^ (string_of_paint_whitout_icc b)
   | #paint_whitout_icc as c -> string_of_paint_whitout_icc c
 
-module Make (Xml : Xml_sigs.T with type ('a, 'b) W.ft = ('a -> 'b)) =
+module Make'
+
+    (Xml : Xml_sigs.T)
+    (C : Svg_sigs.Conv with type ('a, 'b) ft = ('a, 'b) Xml.W.ft) =
+
 struct
 
   module Xml = Xml
@@ -213,6 +186,19 @@ struct
 
   let uri_attrib = Xml.uri_attrib
 
+  (* wrap C module functions *)
+
+  let string_of_coord = C.string_of_length
+
+  let string_of_length = C.string_of_length
+
+  let string_of_lengths = C.string_of_lengths
+
+  let string_of_big_variant :
+    ([< Svg_types.big_variant ], string) C.ft =
+    (C.string_of_big_variant :
+       (Svg_types.big_variant, string) C.ft :>
+       ([< Svg_types.big_variant ], string) C.ft)
 
   (* Custom XML attributes *)
 
@@ -221,6 +207,9 @@ struct
 
   let number_attrib = float_attrib
 
+  (* for now string_attrib, we may want something better in the
+     future. *)
+  let color_attrib = Xml.string_attrib
 
   (* SVG attributes *)
 
@@ -252,8 +241,7 @@ struct
   let a_contentstyletype = string_attrib "contentStyleType"
 
   let a_zoomAndPan x =
-    let f = function `Disable -> "disable" | `Magnify -> "magnify" in
-    user_attrib f "zoomAndSpan" x
+    user_attrib string_of_big_variant "zoomAndSpan" x
 
   let a_xlink_href = string_attrib "xlink:href"
 
@@ -267,7 +255,7 @@ struct
     Xml.comma_sep_attrib "systemLanguage"
 
   let a_externalressourcesrequired =
-    user_attrib string_of_bool "externalRessourcesRequired"
+    user_attrib C.string_of_bool "externalRessourcesRequired"
 
   let a_id = string_attrib "id"
 
@@ -276,8 +264,7 @@ struct
   let a_xml_lang = string_attrib "xml:lang"
 
   let a_xml_space x =
-    let f = function `Default -> "default" | `Preserve -> "preserve" in
-    user_attrib f "xml:space" x
+    user_attrib string_of_big_variant "xml:space" x
 
   let a_type = string_attrib "type"
 
@@ -289,9 +276,9 @@ struct
 
   let a_style = string_attrib "style"
 
-  let a_transform = user_attrib string_of_transform "transform"
+  let a_transform = user_attrib C.string_of_transform "transform"
 
-  let a_viewbox = user_attrib string_of_fourfloats "viewBox"
+  let a_viewbox = user_attrib C.string_of_fourfloats "viewBox"
 
   let a_d = string_attrib "d"
 
@@ -315,69 +302,50 @@ struct
 
   let a_y2 = user_attrib string_of_coord "y2"
 
-  let a_points = user_attrib string_of_coords "points"
+  let a_points = user_attrib C.string_of_coords "points"
 
   let a_x_list = user_attrib string_of_lengths "x"
 
   let a_y_list = user_attrib string_of_lengths "y"
 
-  let a_dx = user_attrib string_of_number "dx"
+  let a_dx = user_attrib C.string_of_number "dx"
 
-  let a_dy = user_attrib string_of_number "dy"
+  let a_dy = user_attrib C.string_of_number "dy"
 
   let a_dx_list = user_attrib string_of_lengths "dx"
 
   let a_dy_list = user_attrib string_of_lengths "dy"
 
   let a_lengthadjust x =
-    let f = function
-      | `Spacing -> "spacing"
-      | `SpacingAndGlyphs -> "spacingAndGlyphs" in
-    user_attrib f "lengthAdjust" x
+    user_attrib string_of_big_variant "lengthAdjust" x
 
   let a_textlength = user_attrib string_of_length "textLength"
 
   let a_text_anchor x =
-    let f = function
-      | `Start -> "start" | `Middle -> "middle"
-      | `End -> "end" | `Inherit -> "inherit" in
-    user_attrib f "text-anchor" x
+    user_attrib string_of_big_variant "text-anchor" x
 
   let a_text_decoration x =
-    let f = function
-      | `None -> "none" | `Underline -> "underline"
-      | `Overline -> "overline" | `Line_through -> "line-through"
-      | `Blink -> "blink" | `Inherit -> "inherit" in
-    user_attrib f "text-decoration" x
+    user_attrib string_of_big_variant "text-decoration" x
 
   let a_text_rendering x =
-    let f = function
-      | `Auto -> "auto"
-      | `OptimizeSpeed -> "optimizeSpeed"
-      | `OptimizeLegibility -> "optimizeLegibility"
-      | `GeometricPrecision -> "geometricPrecision"
-      | `Inherit -> "inherit" in
-    user_attrib f "text-rendering" x
+    user_attrib string_of_big_variant "text-rendering" x
 
-  let a_rotate = user_attrib string_of_numbers "rotate"
+  let a_rotate = user_attrib C.string_of_numbers "rotate"
 
   let a_startoffset = user_attrib string_of_length "startOffset"
 
   let a_method x =
-    let f = function | `Align -> "align" | `Stretch -> "stretch" in
-    user_attrib f "method" x
+    user_attrib string_of_big_variant "method" x
 
   let a_spacing x =
-    let f = function | `Auto -> "auto" | `Exact -> "exact" in
-    user_attrib f "spacing" x
+    user_attrib string_of_big_variant "spacing" x
 
   let a_glyphref = string_attrib "glyphRef"
 
   let a_format = string_attrib "format"
 
   let a_markerunits x =
-    let f = function `StrokeWidth -> "strokeWidth"| `UserSpaceOnUse -> "userSpaceOnUse" in
-    user_attrib f "markerUnits" x
+    user_attrib string_of_big_variant "markerUnits" x
 
   let a_refx = user_attrib string_of_coord "refX"
 
@@ -388,104 +356,60 @@ struct
   let a_markerheight = user_attrib string_of_length "markerHeight"
 
   let a_orient x =
-    let f = function | `Auto -> "auto" | `Angle __svg -> string_of_angle __svg in
-    user_attrib f "orient" x
+    user_attrib C.string_of_orient "orient" x
 
   let a_local = string_attrib "local"
 
   let a_renderingindent x =
-    let f = function
-      | `Auto -> "auto" | `Perceptual -> "perceptual"
-      | `Relative_colorimetric -> "relative_colorimetric" | `Saturation -> "saturation"
-      | `Absolute_colorimetric -> "absolute_colorimetric" in
-    user_attrib f "rendering:indent" x
+    user_attrib string_of_big_variant "rendering:indent" x
 
   let a_gradientunits x =
-    let f = function
-      | `UserSpaceOnUse -> "userSpaceOnUse"
-      | `ObjectBoundingBox -> "objectBoundingBox" in
-    user_attrib f "gradientUnits" x
+    user_attrib string_of_big_variant "gradientUnits" x
 
   let a_gradienttransform =
-    user_attrib string_of_transforms "gradient:transform"
+    user_attrib C.string_of_transforms "gradient:transform"
 
   let a_spreadmethod x =
-    let f = function
-      | `Pad -> "pad"| `Reflect -> "reflect"| `Repeat -> "repeat" in
-    user_attrib f "spreadMethod" x
+    user_attrib string_of_big_variant "spreadMethod" x
 
   let a_fx = user_attrib string_of_coord "fx"
 
   let a_fy = user_attrib string_of_coord "fy"
 
   let a_offset x =
-    let f = function
-      | `Number x -> string_of_number x
-      | `Percentage x -> string_of_percentage x in
-    user_attrib f "offset" x
+    user_attrib C.string_of_offset "offset" x
 
   let a_patternunits x =
-    let f = function
-      | `UserSpaceOnUse -> "userSpaceOnUse"| `ObjectBoundingBox -> "objectBoundingBox" in
-    user_attrib f "patternUnits" x
+    user_attrib string_of_big_variant "patternUnits" x
 
   let a_patterncontentunits x =
-    let f = function | `UserSpaceOnUse -> "userSpaceOnUse"| `ObjectBoundingBox -> "objectBoundingBox" in
-    user_attrib f "patternContentUnits" x
+    user_attrib string_of_big_variant "patternContentUnits" x
 
   let a_patterntransform x =
-    user_attrib string_of_transforms "patternTransform" x
+    user_attrib C.string_of_transforms "patternTransform" x
 
   let a_clippathunits x =
-    let f = function
-      | `UserSpaceOnUse -> "userSpaceOnUse"
-      | `ObjectBoundingBox -> "objectBoundingBox" in
-    user_attrib f "clipPathUnits" x
+    user_attrib string_of_big_variant "clipPathUnits" x
 
   let a_maskunits x =
-    let f = function
-      | `UserSpaceOnUse -> "userSpaceOnUse"
-      | `ObjectBoundingBox -> "objectBoundingBox" in
-    user_attrib f "maskUnits" x
+    user_attrib string_of_big_variant "maskUnits" x
 
   let a_maskcontentunits x =
-    let f = function
-      | `UserSpaceOnUse -> "userSpaceOnUse"
-      | `ObjectBoundingBox -> "objectBoundingBox" in
-    user_attrib f "maskContentUnits" x
+    user_attrib string_of_big_variant "maskContentUnits" x
 
   let a_primitiveunits x =
-    let f = function
-      | `UserSpaceOnUse -> "userSpaceOnUse"
-      | `ObjectBoundingBox -> "objectBoundingBox" in
-    user_attrib f "primitiveUnits" x
+    user_attrib string_of_big_variant "primitiveUnits" x
 
   let a_filterres x =
-    user_attrib string_of_number_optional_number "filterResUnits" x
+    user_attrib C.string_of_number_optional_number "filterResUnits" x
 
   let a_result = string_attrib "result"
 
   let a_in x =
-    let f = function
-      | `SourceGraphic -> "sourceGraphic"
-      | `SourceAlpha -> "sourceAlpha"
-      | `BackgroundImage -> "backgroundImage"
-      | `BackgroundAlpha -> "backgroundAlpha"
-      | `FillPaint -> "fillPaint"
-      | `StrokePaint -> "strokePaint"
-      | `Ref _svg -> _svg in
-    user_attrib f "in" x
+    user_attrib C.string_of_in_value "in" x
 
   let a_in2 x =
-    let f = function
-      | `SourceGraphic -> "sourceGraphic"
-      | `SourceAlpha -> "sourceAlpha"
-      | `BackgroundImage -> "backgroundImage"
-      | `BackgroundAlpha -> "backgroundAlpha"
-      | `FillPaint -> "fillPaint"
-      | `StrokePaint -> "strokePaint"
-      | `Ref _svg -> _svg in
-    user_attrib f "in2" x
+    user_attrib C.string_of_in_value "in2" x
 
   let a_aizmuth = number_attrib "azimuth"
 
@@ -504,150 +428,96 @@ struct
   let a_limitingconeangle = number_attrib "limitingConeAngle"
 
   let a_mode x =
-    let f = function
-      | `Normal -> "normal"
-      | `Multiply -> "multiply"
-      | `Screen -> "screen"
-      | `Darken -> "darken"
-      | `Lighten -> "lighten" in
-    user_attrib f "mode" x
+    user_attrib string_of_big_variant "mode" x
 
   let a_typefecolor x =
-    let f = function
-      | `Matrix -> "matrix"
-      | `Saturate -> "saturate"
-      | `HueRotate -> "hueRotate"
-      | `LuminanceToAlpha -> "luminanceToAlpha" in
-    user_attrib f "type" x
+    user_attrib string_of_big_variant "type" x
 
-  let a_values = user_attrib string_of_numbers "values"
+  let a_values = user_attrib C.string_of_numbers "values"
 
   let a_transferttype x =
-    let f = function
-      | `Identity -> "identity"
-      | `Table -> "table"
-      | `Discrete -> "discrete"
-      | `Linear -> "linear"
-      | `Gamma -> "gamma" in
-    user_attrib f "type" x
+    user_attrib string_of_big_variant "type" x
 
-  let a_tablevalues = user_attrib string_of_numbers "tableValues"
+  let a_tablevalues = user_attrib C.string_of_numbers "tableValues"
 
-  let a_intercept = user_attrib string_of_number "intercept"
+  let a_intercept = user_attrib C.string_of_number "intercept"
 
-  let a_amplitude = user_attrib string_of_number "amplitude"
+  let a_amplitude = user_attrib C.string_of_number "amplitude"
 
-  let a_exponent = user_attrib string_of_number "exponent"
+  let a_exponent = user_attrib C.string_of_number "exponent"
 
-  let a_offsettransfer = user_attrib string_of_number "offset"
+  let a_offsettransfer = user_attrib C.string_of_number "offset"
 
   let a_operator x =
-    let f = function
-      | `Over -> "over"
-      | `In -> "in"
-      | `Out -> "out"
-      | `Atop -> "atop"
-      | `Xor -> "xor"
-      | `Arithmetic -> "arithmetic" in
-    user_attrib f "operator" x
+    user_attrib string_of_big_variant "operator" x
 
-  let a_k1 = user_attrib string_of_number "k1"
+  let a_k1 = user_attrib C.string_of_number "k1"
 
-  let a_k2 = user_attrib string_of_number "k2"
+  let a_k2 = user_attrib C.string_of_number "k2"
 
-  let a_k3 = user_attrib string_of_number "k3"
+  let a_k3 = user_attrib C.string_of_number "k3"
 
-  let a_k4 = user_attrib string_of_number "k4"
+  let a_k4 = user_attrib C.string_of_number "k4"
 
-  let a_order = user_attrib string_of_number_optional_number "order"
+  let a_order = user_attrib C.string_of_number_optional_number "order"
 
-  let a_kernelmatrix = user_attrib string_of_numbers "kernelMatrix"
+  let a_kernelmatrix = user_attrib C.string_of_numbers "kernelMatrix"
 
-  let a_divisor = user_attrib string_of_number "divisor"
+  let a_divisor = user_attrib C.string_of_number "divisor"
 
-  let a_bias = user_attrib string_of_number "bias"
+  let a_bias = user_attrib C.string_of_number "bias"
 
   let a_kernelunitlength =
-    user_attrib string_of_number_optional_number "kernelUnitLength"
+    user_attrib C.string_of_number_optional_number "kernelUnitLength"
 
-  let a_targetX = user_attrib string_of_int "targetX"
+  let a_targetX = user_attrib C.string_of_int "targetX"
 
-  let a_targetY = user_attrib string_of_int "targetY"
+  let a_targetY = user_attrib C.string_of_int "targetY"
 
   let a_edgemode x =
-    let f = function
-      | `Duplicate -> "duplicate"
-      | `Wrap -> "wrap"
-      | `None -> "none" in
-    user_attrib f "targetY" x
+    user_attrib string_of_big_variant "targetY" x
 
-  let a_preservealpha = user_attrib string_of_bool "targetY"
+  let a_preservealpha = user_attrib C.string_of_bool "targetY"
 
-  let a_surfacescale = user_attrib string_of_number "surfaceScale"
+  let a_surfacescale = user_attrib C.string_of_number "surfaceScale"
 
-  let a_diffuseconstant = user_attrib string_of_number "diffuseConstant"
+  let a_diffuseconstant =
+    user_attrib C.string_of_number "diffuseConstant"
 
-  let a_scale = user_attrib string_of_number "scale"
+  let a_scale = user_attrib C.string_of_number "scale"
 
   let a_xchannelselector x =
-    let f = function
-      | `R -> "r"
-      | `G -> "g"
-      | `B -> "b"
-      | `A -> "a" in
-    user_attrib f "xChannelSelector" x
+    user_attrib string_of_big_variant "xChannelSelector" x
 
   let a_ychannelselector x =
-    let f = function
-      | `R -> "r"
-      | `G -> "g"
-      | `B -> "b"
-      | `A -> "a" in
-    user_attrib f "yChannelSelector" x
+    user_attrib string_of_big_variant "yChannelSelector" x
 
   let a_stddeviation =
-    user_attrib string_of_number_optional_number "stdDeviation"
+    user_attrib C.string_of_number_optional_number "stdDeviation"
 
   let a_operatormorphology x =
-    let f = function
-      | `Erode -> "erode"
-      | `Dilate -> "dilate" in
-    user_attrib f "operatorMorphology" x
+    user_attrib string_of_big_variant "operatorMorphology" x
 
-  let a_radius = user_attrib string_of_number_optional_number "radius"
+  let a_radius = user_attrib C.string_of_number_optional_number "radius"
 
   let a_basefrenquency =
-    user_attrib string_of_number_optional_number "baseFrequency"
+    user_attrib C.string_of_number_optional_number "baseFrequency"
 
-  let a_numoctaves = user_attrib string_of_int "numOctaves"
+  let a_numoctaves = user_attrib C.string_of_int "numOctaves"
 
-  let a_seed = user_attrib string_of_number "seed"
+  let a_seed = user_attrib C.string_of_number "seed"
 
   let a_stitchtiles x =
-    let f = function
-      | `Stitch -> "stitch"
-      | `NoStitch -> "noStitch" in
-    user_attrib f "stitchTiles" x
+    user_attrib string_of_big_variant "stitchTiles" x
 
   let a_stitchtype x =
-    let f = function
-      | `FractalNoise -> "fractalNoise"
-      | `Turbulence -> "turbulence" in
-    user_attrib f "typeStitch" x
+    user_attrib string_of_big_variant "typeStitch" x
 
   let a_xlinkshow x =
-    let f = function
-      | `New -> "new"
-      | `Replace -> "replace" in
-    user_attrib f "xlink:show" x
+    user_attrib string_of_big_variant "xlink:show" x
 
   let a_xlinkactuate x =
-    let f = function
-      | `OnRequest -> "onRequest"
-      | `OnLoad -> "onLoad"
-      | `Other -> "other"
-      | `None -> "none"
-    in user_attrib f "xlink:actuate" x
+    user_attrib string_of_big_variant "xlink:actuate" x
 
   let a_target = string_attrib "xlink:target"
 
@@ -656,11 +526,7 @@ struct
   let a_attributename = string_attrib "attributeName"
 
   let a_attributetype x =
-    let f = function
-      | `CSS -> "CSS"
-      | `XML -> "XML"
-      | `Auto -> "auto" in
-    user_attrib f "attributeType" x
+    user_attrib string_of_big_variant "attributeType" x
 
   let a_begin = string_attrib "begin"
 
@@ -671,31 +537,19 @@ struct
   let a_max = string_attrib "max"
 
   let a_restart x =
-    let f = function
-      | `Always -> "always"
-      | `WhenNotActive -> "whenNotActive"
-      | `Never -> "never" in
-    user_attrib f "restart" x
+    user_attrib string_of_big_variant "restart" x
 
   let a_repeatcount = string_attrib "repeatCount"
 
   let a_repeatdur = string_attrib "repeatDur"
 
-  let a_fill = user_attrib string_of_paint "fill"
+  let a_fill = user_attrib C.string_of_paint "fill"
 
   let a_fill_animation x =
-    let f = function
-      | `Freeze -> "freeze"
-      | `Remove -> "remove" in
-    user_attrib f "fill" x
+    user_attrib string_of_big_variant "fill" x
 
   let a_calcmode x =
-    let f = function
-      | `Discrete -> "discrete"
-      | `Linear -> "linear"
-      | `Paced -> "paced"
-      | `Spline -> "spline" in
-    user_attrib f "calcMode" x
+    user_attrib string_of_big_variant "calcMode" x
 
   let a_values_anim = Xml.comma_sep_attrib "values"
 
@@ -710,59 +564,39 @@ struct
   let a_by = string_attrib "by"
 
   let a_additive x =
-    let f = function
-      | `Replace -> "replace"
-      | `Sum -> "sum" in
-    user_attrib f "additive" x
+    user_attrib string_of_big_variant "additive" x
 
   let a_accumulate x =
-    let f = function
-      | `None -> "none"
-      | `Sum -> "sum" in
-    user_attrib f "accumulate" x
+    user_attrib string_of_big_variant "accumulate" x
 
-  let a_keypoints = user_attrib string_of_numbers_semicolon "keyPoints"
+  let a_keypoints = user_attrib C.string_of_numbers_semicolon "keyPoints"
 
   let a_path = string_attrib "path"
 
   let a_typeanimatecolor x =
-    let f = function
-      | `Translate -> "translate"
-      | `Scale -> "scale"
-      | `Rotate -> "rotate"
-      | `SkewX -> "skewX"
-      | `SkewY -> "skewY" in
-    user_attrib f "type" x
+    user_attrib string_of_big_variant "type" x
 
-  let a_horiz_origin_x = user_attrib string_of_number "horiz-origin-x"
+  let a_horiz_origin_x = user_attrib C.string_of_number "horiz-origin-x"
 
-  let a_horiz_origin_y = user_attrib string_of_number "horiz-origin-y"
+  let a_horiz_origin_y = user_attrib C.string_of_number "horiz-origin-y"
 
-  let a_horiz_adv_x = user_attrib string_of_number "horiz-adv-x"
+  let a_horiz_adv_x = user_attrib C.string_of_number "horiz-adv-x"
 
-  let a_vert_origin_x = user_attrib string_of_number "vert-origin-x"
+  let a_vert_origin_x = user_attrib C.string_of_number "vert-origin-x"
 
-  let a_vert_origin_y = user_attrib string_of_number "vert-origin-y"
+  let a_vert_origin_y = user_attrib C.string_of_number "vert-origin-y"
 
-  let a_vert_adv_y = user_attrib string_of_number "vert-adv-y"
+  let a_vert_adv_y = user_attrib C.string_of_number "vert-adv-y"
 
   let a_unicode = string_attrib "unicode"
 
   let a_glyphname = string_attrib "glyphname"
 
   let a_orientation x =
-    let f = function
-      | `H -> "h"
-      | `V -> "v" in
-    user_attrib f "orientation" x
+    user_attrib string_of_big_variant "orientation" x
 
   let a_arabicform x =
-    let f = function
-      | `Initial -> "initial"
-      | `Medial -> "medial"
-      | `Terminal -> "terminal"
-      | `Isolated -> "isolated" in
-    user_attrib f "arabic-form" x
+    user_attrib string_of_big_variant "arabic-form" x
 
   let a_lang = string_attrib "lang"
 
@@ -792,96 +626,66 @@ struct
 
   let a_unitsperem = string_attrib "units-per-em"
 
-  let a_stemv = user_attrib string_of_number "stemv"
+  let a_stemv = user_attrib C.string_of_number "stemv"
 
-  let a_stemh = user_attrib string_of_number "stemh"
+  let a_stemh = user_attrib C.string_of_number "stemh"
 
-  let a_slope = user_attrib string_of_number "slope"
+  let a_slope = user_attrib C.string_of_number "slope"
 
-  let a_capheight = user_attrib string_of_number "cap-height"
+  let a_capheight = user_attrib C.string_of_number "cap-height"
 
-  let a_xheight = user_attrib string_of_number "x-height"
+  let a_xheight = user_attrib C.string_of_number "x-height"
 
-  let a_accentheight = user_attrib string_of_number "accent-height"
+  let a_accentheight = user_attrib C.string_of_number "accent-height"
 
-  let a_ascent = user_attrib string_of_number "ascent"
+  let a_ascent = user_attrib C.string_of_number "ascent"
 
   let a_widths = string_attrib "widths"
 
   let a_bbox = string_attrib "bbox"
 
-  let a_ideographic = user_attrib string_of_number "ideographic"
+  let a_ideographic = user_attrib C.string_of_number "ideographic"
 
-  let a_alphabetic = user_attrib string_of_number "alphabetic"
+  let a_alphabetic = user_attrib C.string_of_number "alphabetic"
 
-  let a_mathematical = user_attrib string_of_number "mathematical"
+  let a_mathematical = user_attrib C.string_of_number "mathematical"
 
-  let a_hanging = user_attrib string_of_number "hanging"
+  let a_hanging = user_attrib C.string_of_number "hanging"
 
-  let a_videographic = user_attrib string_of_number "v-ideographic"
+  let a_videographic = user_attrib C.string_of_number "v-ideographic"
 
-  let a_valphabetic = user_attrib string_of_number "v-alphabetic"
+  let a_valphabetic = user_attrib C.string_of_number "v-alphabetic"
 
-  let a_vmathematical = user_attrib string_of_number "v-mathematical"
+  let a_vmathematical = user_attrib C.string_of_number "v-mathematical"
 
-  let a_vhanging = user_attrib string_of_number "v-hanging"
+  let a_vhanging = user_attrib C.string_of_number "v-hanging"
 
   let a_underlineposition =
-    user_attrib string_of_number "underline-position"
+    user_attrib C.string_of_number "underline-position"
 
   let a_underlinethickness =
-    user_attrib string_of_number "underline-thickness"
+    user_attrib C.string_of_number "underline-thickness"
 
   let a_strikethroughposition =
-    user_attrib string_of_number "strikethrough-position"
+    user_attrib C.string_of_number "strikethrough-position"
 
   let a_strikethroughthickness =
-    user_attrib string_of_number "strikethrough-thickness"
+    user_attrib C.string_of_number "strikethrough-thickness"
 
-  let a_overlineposition = user_attrib string_of_number "overline-position"
+  let a_overlineposition = user_attrib C.string_of_number "overline-position"
 
   let a_overlinethickness =
-    user_attrib string_of_number "overline-thickness"
+    user_attrib C.string_of_number "overline-thickness"
 
   let a_string = string_attrib "string"
 
   let a_name = string_attrib "name"
 
-  let string_of_alignment_baseline = function
-    | `Auto -> "auto"
-    | `Baseline -> "baseline"
-    | `Before_edge -> "before-edge"
-    | `Text_before_edge -> "text-before-edge"
-    | `Middle -> "middle"
-    | `Central -> "central"
-    | `After_edge -> "after-edge"
-    | `Text_after_edge -> "text-after-edge"
-    | `Ideographic -> "ideographic"
-    | `Alphabetic -> "alphabetic"
-    | `Hanging-> "hanging"
-    | `Mathematical -> "mathematical"
-    | `Inherit -> "inherit"
-
   let a_alignment_baseline x =
-    user_attrib string_of_alignment_baseline "alignment-baseline" x
-
-  let string_of_dominant_baseline = function
-    | `Auto -> "auto"
-    | `Use_script -> "use-script"
-    | `No_change -> "no-change"
-    | `Reset_size -> "reset-size"
-    | `Ideographic -> "ideographic"
-    | `Alphabetic -> "alphabetic"
-    | `Hanging -> "hanging"
-    | `Mathematical -> "mathematical"
-    | `Central -> "central"
-    | `Middle -> "middle"
-    | `Text_after_edge -> "text-after-edge"
-    | `Text_before_edge -> "text-before-edge"
-    | `Inherit -> "inherit"
+    user_attrib C.string_of_alignment_baseline "alignment-baseline" x
 
   let a_dominant_baseline x =
-    user_attrib string_of_dominant_baseline "dominant-baseline" x
+    user_attrib C.string_of_dominant_baseline "dominant-baseline" x
 
   (** Javascript events *)
 
@@ -908,43 +712,31 @@ struct
   let a_onmouseout = Xml.mouse_event_handler_attrib "onmouseout"
   let a_onmousemove = Xml.mouse_event_handler_attrib "onmousemove"
 
+  let a_stopcolor = color_attrib "stop-color"
 
-  let a_stopcolor = user_attrib string_of_color "stop-color"
+  let a_stopopacity = user_attrib C.string_of_number "stop-opacity"
 
-  let a_stopopacity = user_attrib string_of_number "stop-opacity"
+  let a_stroke = user_attrib C.string_of_paint "stroke"
 
-  let a_stroke = user_attrib string_of_paint "stroke"
-
-  let a_strokewidth = user_attrib string_of_length "stroke-width"
+  let a_strokewidth = user_attrib C.string_of_length "stroke-width"
 
   let a_strokelinecap x =
-    let f = function
-      | `Butt -> "butt"
-      | `Round -> "round"
-      | `Square -> "square" in
-    user_attrib f "stroke-linecap" x
+    user_attrib string_of_big_variant "stroke-linecap" x
 
   let a_strokelinejoin x =
-    let f = function
-      | `Miter -> "miter"
-      | `Round -> "round"
-      | `Bever -> "bevel" in
-    user_attrib f "stroke-linejoin" x
+    user_attrib string_of_big_variant "stroke-linejoin" x
 
   let a_strokemiterlimit =
-    user_attrib string_of_number "stroke-miterlimit"
+    user_attrib C.string_of_number "stroke-miterlimit"
 
   let a_strokedasharray x =
-    let f = function
-      | [] -> "none"
-      | l -> list string_of_length l in
-    user_attrib f "stroke-dasharray" x
+    user_attrib C.string_of_strokedasharray "stroke-dasharray" x
 
   let a_strokedashoffset =
-    user_attrib string_of_length "stroke-dashoffset"
+    user_attrib C.string_of_length "stroke-dashoffset"
 
   let a_strokeopacity =
-    user_attrib string_of_number "stroke-opacity"
+    user_attrib C.string_of_number "stroke-opacity"
 
   (* xlink namespace given a nickname since some attributes mandated by
      the svg standard such as xlink:href live in that namespace, and we
@@ -956,7 +748,7 @@ struct
       :: string_attrib "xmlns:xlink" (W.return "http://www.w3.org/1999/xlink")
       :: to_xmlattribs a
     in
-    star ~a:(attribs) "svg" (W.map toeltl children)
+    star ~a:(attribs) "svg" children
 
   (* also generated *)
   let g = star "g"
@@ -1137,3 +929,208 @@ struct
   end
 
 end
+
+module Conv = struct
+
+  type (-'a, 'b) ft = 'a -> 'b
+
+  let string_of_alignment_baseline = function
+    | `Auto -> "auto"
+    | `Baseline -> "baseline"
+    | `Before_edge -> "before-edge"
+    | `Text_before_edge -> "text-before-edge"
+    | `Middle -> "middle"
+    | `Central -> "central"
+    | `After_edge -> "after-edge"
+    | `Text_after_edge -> "text-after-edge"
+    | `Ideographic -> "ideographic"
+    | `Alphabetic -> "alphabetic"
+    | `Hanging-> "hanging"
+    | `Mathematical -> "mathematical"
+    | `Inherit -> "inherit"
+
+  let string_of_big_variant = function
+    | `A -> "a"
+    | `Absolute_colorimetric -> "absolute_colorimetric"
+    | `Align -> ""
+    | `Always -> "always"
+    | `Atop -> "atop"
+    | `Arithmetic -> "arithmetic"
+    | `Auto -> "auto"
+    | `B -> "b"
+    | `Bever -> "bevel"
+    | `Blink -> "blink"
+    | `Butt -> "butt"
+    | `CSS -> "CSS"
+    | `Darken -> "darken"
+    | `Default -> "default"
+    | `Dilate -> "dilate"
+    | `Disable -> "disable"
+    | `Discrete -> "discrete"
+    | `Duplicate -> "duplicate"
+    | `End -> "end"
+    | `Erode -> "erode"
+    | `Exact -> "exact"
+    | `FractalNoise -> "fractalNoise"
+    | `Freeze -> "freeze"
+    | `HueRotate -> "hueRotate"
+    | `G -> "g"
+    | `Gamma -> "gamma"
+    | `GeometricPrecision -> "geometricPrecision"
+    | `H -> "h"
+    | `Identity -> "identity"
+    | `In -> "in"
+    | `Inherit -> "inherit"
+    | `Initial -> "initial"
+    | `Isolated -> "isolated"
+    | `Lighten -> "lighten"
+    | `Line_through -> "line-through"
+    | `Linear -> "linear"
+    | `LuminanceToAlpha -> "luminanceToAlpha"
+    | `Magnify -> "magnify"
+    | `Matrix -> "matrix"
+    | `Medial -> "medial"
+    | `Middle -> "middle"
+    | `Miter -> "miter"
+    | `Multiply -> "multiply"
+    | `Never -> "never"
+    | `New -> "new"
+    | `None -> "none"
+    | `Normal -> "normal"
+    | `NoStitch -> "noStitch"
+    | `ObjectBoundingBox -> "objectBoundingBox"
+    | `OnLoad -> "onLoad"
+    | `OnRequest -> "onRequest"
+    | `OptimizeLegibility -> "optimizeLegibility"
+    | `OptimizeSpeed -> "optimizeSpeed"
+    | `Other -> "other"
+    | `Out -> "out"
+    | `Over -> "over"
+    | `Overline -> "overline"
+    | `Paced -> "paced"
+    | `Pad -> "pad"
+    | `Perceptual -> "perceptual"
+    | `Preserve -> "preserve"
+    | `R -> "r"
+    | `Reflect -> "reflect"
+    | `Remove -> "remove"
+    | `Repeat -> "repeat"
+    | `Replace -> "replace"
+    | `Relative_colorimetric -> "relative_colorimetric"
+    | `Rotate -> "rotate"
+    | `Round -> "round"
+    | `Saturate -> "saturate"
+    | `Saturation -> "saturation"
+    | `Scale -> "scale"
+    | `Screen -> "screen"
+    | `SkewX -> "skewX"
+    | `SkewY -> "skewY"
+    | `Spacing -> "spacing"
+    | `SpacingAndGlyphs -> "spacingAndGlyphs"
+    | `Spline -> "spline"
+    | `Square -> "square"
+    | `Start -> "start"
+    | `Stitch -> "stitch"
+    | `Stretch -> "stretch"
+    | `StrokeWidth -> "stroke-width"
+    | `Sum -> "sum"
+    | `Table -> "table"
+    | `Terminal -> "terminal"
+    | `Translate -> "translate"
+    | `Turbulence -> "turbulence"
+    | `Underline -> "underline"
+    | `UserSpaceOnUse -> "userSpaceOnUse"
+    | `V -> "v"
+    | `WhenNotActive -> "whenNotActive"
+    | `Wrap -> "wrap"
+    | `XML -> "XML"
+    | `Xor -> "xor"
+
+  let string_of_bool = string_of_bool
+
+  let string_of_coords =
+    list (fun (a, b) -> Printf.sprintf "%g, %g" a b)
+
+  let string_of_dominant_baseline = function
+    | `Auto -> "auto"
+    | `Use_script -> "usescript"
+    | `No_change -> "nochange"
+    | `Reset_size -> "resetsize"
+    | `Ideographic -> "ideographic"
+    | `Alphabetic -> "alphabetic"
+    | `Hanging -> "hanging"
+    | `Mathematical -> "mathematical"
+    | `Central -> "central"
+    | `Middle -> "middle"
+    | `Text_after_edge -> "textafteredge"
+    | `Text_before_edge -> "textbeforeedge"
+    | `Inherit -> "inherit"
+
+  let string_of_fourfloats (a, b, c, d) =
+    Printf.sprintf "%g %g %g %g" a b c d
+
+  let string_of_in_value = function
+    | `SourceGraphic -> "sourceGraphic"
+    | `SourceAlpha -> "sourceAlpha"
+    | `BackgroundImage -> "backgroundImage"
+    | `BackgroundAlpha -> "backgroundAlpha"
+    | `FillPaint -> "fillPaint"
+    | `StrokePaint -> "strokePaint"
+    | `Ref _svg -> _svg
+
+  let string_of_int = string_of_int
+
+  let string_of_length = Unit.string_of_length
+
+  let string_of_lengths = list string_of_length
+
+  let string_of_number = string_of_float
+
+  let string_of_number_optional_number = function
+    | x, Some y -> Printf.sprintf "%g, %g" x y
+    | x, None -> Printf.sprintf "%g" x
+
+  let string_of_numbers = list string_of_float
+
+  let string_of_numbers_semicolon = list ~sep:"; " string_of_float
+
+  let string_of_offset = function
+    | `Number x -> string_of_number x
+    | `Percentage x -> string_of_percentage x
+
+  let string_of_orient = function
+    | `Auto -> "auto"
+    | `Angle __svg -> string_of_angle __svg
+
+  let string_of_paint = string_of_paint
+
+  let string_of_strokedasharray = function
+    | [] -> "none"
+    | l -> list string_of_length l
+
+  let string_of_transform = function
+    | Matrix (a, b, c, d, e, f) ->
+      Printf.sprintf "matrix(%g %g %g %g %g %g)" a b c d e f
+    | Translate x ->
+      Printf.sprintf "translate(%s)"
+        (string_of_number_optional_number x)
+    | Scale x ->
+      Printf.sprintf "scale(%s)" (string_of_number_optional_number x)
+    | Rotate ((angle, x)) ->
+      Printf.sprintf "rotate(%s %s)" (string_of_angle angle)
+        (match x with
+         | Some ((x, y)) -> Printf.sprintf "%g %g" x y
+         | None -> "")
+    | SkewX angle ->
+      Printf.sprintf "skewX(%s)" (string_of_angle angle)
+    | SkewY angle ->
+      Printf.sprintf "skewY(%s)" (string_of_angle angle)
+
+  let string_of_transforms l =
+    String.concat " " (List.map string_of_transform l)
+
+end
+
+module Make
+    (Xml : Xml_sigs.T with type ('a, 'b) W.ft = ('a -> 'b)) =
+  Make'(Xml)(Conv)

--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -104,10 +104,11 @@ let string_of_paint = function
     (string_of_iri iri) ^" "^ (string_of_paint_whitout_icc b)
   | #paint_whitout_icc as c -> string_of_paint_whitout_icc c
 
-module Make'
+module Make_with_wrapped_functions
 
     (Xml : Xml_sigs.T)
-    (C : Svg_sigs.Conv with type ('a, 'b) ft = ('a, 'b) Xml.W.ft) =
+    (C : Svg_sigs.Wrapped_functions
+     with type ('a, 'b) ft = ('a, 'b) Xml.W.ft) =
 
 struct
 
@@ -924,7 +925,7 @@ struct
 
 end
 
-module Conv = struct
+module Wrapped_functions = struct
 
   type (-'a, 'b) ft = 'a -> 'b
 
@@ -1127,4 +1128,4 @@ end
 
 module Make
     (Xml : Xml_sigs.T with type ('a, 'b) W.ft = ('a -> 'b)) =
-  Make'(Xml)(Conv)
+  Make_with_wrapped_functions(Xml)(Wrapped_functions)

--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -234,8 +234,8 @@ struct
 
   let a_contentstyletype = string_attrib "contentStyleType"
 
-  let a_zoomAndPan =
-    user_attrib C.string_of_big_variant "zoomAndSpan"
+  let a_zoomAndPan x =
+    user_attrib C.string_of_big_variant "zoomAndSpan" x
 
   let a_xlink_href = string_attrib "xlink:href"
 
@@ -257,8 +257,8 @@ struct
 
   let a_xml_lang = string_attrib "xml:lang"
 
-  let a_xml_space =
-    user_attrib C.string_of_big_variant "xml:space"
+  let a_xml_space x =
+    user_attrib C.string_of_big_variant "xml:space" x
 
   let a_type = string_attrib "type"
 
@@ -310,36 +310,36 @@ struct
 
   let a_dy_list = user_attrib string_of_lengths "dy"
 
-  let a_lengthadjust =
-    user_attrib C.string_of_big_variant "lengthAdjust"
+  let a_lengthadjust x =
+    user_attrib C.string_of_big_variant "lengthAdjust" x
 
   let a_textlength = user_attrib string_of_length "textLength"
 
-  let a_text_anchor =
-    user_attrib C.string_of_big_variant "text-anchor"
+  let a_text_anchor x =
+    user_attrib C.string_of_big_variant "text-anchor" x
 
-  let a_text_decoration =
-    user_attrib C.string_of_big_variant "text-decoration"
+  let a_text_decoration x =
+    user_attrib C.string_of_big_variant "text-decoration" x
 
-  let a_text_rendering =
-    user_attrib C.string_of_big_variant "text-rendering"
+  let a_text_rendering x =
+    user_attrib C.string_of_big_variant "text-rendering" x
 
   let a_rotate = user_attrib C.string_of_numbers "rotate"
 
   let a_startoffset = user_attrib string_of_length "startOffset"
 
-  let a_method =
-    user_attrib C.string_of_big_variant "method"
+  let a_method x =
+    user_attrib C.string_of_big_variant "method" x
 
-  let a_spacing =
-    user_attrib C.string_of_big_variant "spacing"
+  let a_spacing x =
+    user_attrib C.string_of_big_variant "spacing" x
 
   let a_glyphref = string_attrib "glyphRef"
 
   let a_format = string_attrib "format"
 
-  let a_markerunits =
-    user_attrib C.string_of_big_variant "markerUnits"
+  let a_markerunits x =
+    user_attrib C.string_of_big_variant "markerUnits" x
 
   let a_refx = user_attrib string_of_coord "refX"
 
@@ -354,17 +354,17 @@ struct
 
   let a_local = string_attrib "local"
 
-  let a_renderingindent =
-    user_attrib C.string_of_big_variant "rendering:indent"
+  let a_renderingindent x =
+    user_attrib C.string_of_big_variant "rendering:indent" x
 
-  let a_gradientunits =
-    user_attrib C.string_of_big_variant "gradientUnits"
+  let a_gradientunits x =
+    user_attrib C.string_of_big_variant "gradientUnits" x
 
   let a_gradienttransform =
     user_attrib C.string_of_transforms "gradient:transform"
 
-  let a_spreadmethod =
-    user_attrib C.string_of_big_variant "spreadMethod"
+  let a_spreadmethod x =
+    user_attrib C.string_of_big_variant "spreadMethod" x
 
   let a_fx = user_attrib string_of_coord "fx"
 
@@ -373,37 +373,37 @@ struct
   let a_offset x =
     user_attrib C.string_of_offset "offset" x
 
-  let a_patternunits =
-    user_attrib C.string_of_big_variant "patternUnits"
+  let a_patternunits x =
+    user_attrib C.string_of_big_variant "patternUnits" x
 
-  let a_patterncontentunits =
-    user_attrib C.string_of_big_variant "patternContentUnits"
+  let a_patterncontentunits x =
+    user_attrib C.string_of_big_variant "patternContentUnits" x
 
   let a_patterntransform x =
     user_attrib C.string_of_transforms "patternTransform" x
 
-  let a_clippathunits =
-    user_attrib C.string_of_big_variant "clipPathUnits"
+  let a_clippathunits x =
+    user_attrib C.string_of_big_variant "clipPathUnits" x
 
-  let a_maskunits =
-    user_attrib C.string_of_big_variant "maskUnits"
+  let a_maskunits x =
+    user_attrib C.string_of_big_variant "maskUnits" x
 
-  let a_maskcontentunits =
-    user_attrib C.string_of_big_variant "maskContentUnits"
+  let a_maskcontentunits x =
+    user_attrib C.string_of_big_variant "maskContentUnits" x
 
-  let a_primitiveunits =
-    user_attrib C.string_of_big_variant "primitiveUnits"
+  let a_primitiveunits x =
+    user_attrib C.string_of_big_variant "primitiveUnits" x
 
   let a_filterres =
     user_attrib C.string_of_number_optional_number "filterResUnits"
 
   let a_result = string_attrib "result"
 
-  let a_in =
-    user_attrib C.string_of_in_value "in"
+  let a_in x =
+    user_attrib C.string_of_in_value "in" x
 
-  let a_in2 =
-    user_attrib C.string_of_in_value "in2"
+  let a_in2 x =
+    user_attrib C.string_of_in_value "in2" x
 
   let a_aizmuth = number_attrib "azimuth"
 
@@ -421,16 +421,16 @@ struct
 
   let a_limitingconeangle = number_attrib "limitingConeAngle"
 
-  let a_mode =
-    user_attrib C.string_of_big_variant "mode"
+  let a_mode x =
+    user_attrib C.string_of_big_variant "mode" x
 
-  let a_typefecolor =
-    user_attrib C.string_of_big_variant "type"
+  let a_typefecolor x =
+    user_attrib C.string_of_big_variant "type" x
 
   let a_values = user_attrib C.string_of_numbers "values"
 
-  let a_transferttype =
-    user_attrib C.string_of_big_variant "type"
+  let a_transferttype x =
+    user_attrib C.string_of_big_variant "type" x
 
   let a_tablevalues = user_attrib C.string_of_numbers "tableValues"
 
@@ -442,8 +442,8 @@ struct
 
   let a_offsettransfer = user_attrib C.string_of_number "offset"
 
-  let a_operator =
-    user_attrib C.string_of_big_variant "operator"
+  let a_operator x =
+    user_attrib C.string_of_big_variant "operator" x
 
   let a_k1 = user_attrib C.string_of_number "k1"
 
@@ -468,8 +468,8 @@ struct
 
   let a_targetY = user_attrib C.string_of_int "targetY"
 
-  let a_edgemode =
-    user_attrib C.string_of_big_variant "targetY"
+  let a_edgemode x =
+    user_attrib C.string_of_big_variant "targetY" x
 
   let a_preservealpha = user_attrib C.string_of_bool "targetY"
 
@@ -480,17 +480,17 @@ struct
 
   let a_scale = user_attrib C.string_of_number "scale"
 
-  let a_xchannelselector =
-    user_attrib C.string_of_big_variant "xChannelSelector"
+  let a_xchannelselector x =
+    user_attrib C.string_of_big_variant "xChannelSelector" x
 
-  let a_ychannelselector =
-    user_attrib C.string_of_big_variant "yChannelSelector"
+  let a_ychannelselector x =
+    user_attrib C.string_of_big_variant "yChannelSelector" x
 
   let a_stddeviation =
     user_attrib C.string_of_number_optional_number "stdDeviation"
 
-  let a_operatormorphology =
-    user_attrib C.string_of_big_variant "operatorMorphology"
+  let a_operatormorphology x =
+    user_attrib C.string_of_big_variant "operatorMorphology" x
 
   let a_radius = user_attrib C.string_of_number_optional_number "radius"
 
@@ -501,17 +501,17 @@ struct
 
   let a_seed = user_attrib C.string_of_number "seed"
 
-  let a_stitchtiles =
-    user_attrib C.string_of_big_variant "stitchTiles"
+  let a_stitchtiles x =
+    user_attrib C.string_of_big_variant "stitchTiles" x
 
-  let a_stitchtype =
-    user_attrib C.string_of_big_variant "typeStitch"
+  let a_stitchtype x =
+    user_attrib C.string_of_big_variant "typeStitch" x
 
-  let a_xlinkshow =
-    user_attrib C.string_of_big_variant "xlink:show"
+  let a_xlinkshow x =
+    user_attrib C.string_of_big_variant "xlink:show" x
 
-  let a_xlinkactuate =
-    user_attrib C.string_of_big_variant "xlink:actuate"
+  let a_xlinkactuate x =
+    user_attrib C.string_of_big_variant "xlink:actuate" x
 
   let a_target = string_attrib "xlink:target"
 
@@ -519,8 +519,8 @@ struct
 
   let a_attributename = string_attrib "attributeName"
 
-  let a_attributetype =
-    user_attrib C.string_of_big_variant "attributeType"
+  let a_attributetype x =
+    user_attrib C.string_of_big_variant "attributeType" x
 
   let a_begin = string_attrib "begin"
 
@@ -530,8 +530,8 @@ struct
 
   let a_max = string_attrib "max"
 
-  let a_restart =
-    user_attrib C.string_of_big_variant "restart"
+  let a_restart x =
+    user_attrib C.string_of_big_variant "restart" x
 
   let a_repeatcount = string_attrib "repeatCount"
 
@@ -539,11 +539,11 @@ struct
 
   let a_fill = user_attrib C.string_of_paint "fill"
 
-  let a_fill_animation =
-    user_attrib C.string_of_big_variant "fill"
+  let a_fill_animation x =
+    user_attrib C.string_of_big_variant "fill" x
 
-  let a_calcmode =
-    user_attrib C.string_of_big_variant "calcMode"
+  let a_calcmode x =
+    user_attrib C.string_of_big_variant "calcMode" x
 
   let a_values_anim = Xml.comma_sep_attrib "values"
 
@@ -557,11 +557,11 @@ struct
 
   let a_by = string_attrib "by"
 
-  let a_additive =
-    user_attrib C.string_of_big_variant "additive"
+  let a_additive x =
+    user_attrib C.string_of_big_variant "additive" x
 
-  let a_accumulate =
-    user_attrib C.string_of_big_variant "accumulate"
+  let a_accumulate x =
+    user_attrib C.string_of_big_variant "accumulate" x
 
   let a_keypoints = user_attrib C.string_of_numbers_semicolon "keyPoints"
 
@@ -586,11 +586,11 @@ struct
 
   let a_glyphname = string_attrib "glyphname"
 
-  let a_orientation =
-    user_attrib C.string_of_big_variant "orientation"
+  let a_orientation x =
+    user_attrib C.string_of_big_variant "orientation" x
 
-  let a_arabicform =
-    user_attrib C.string_of_big_variant "arabic-form"
+  let a_arabicform x =
+    user_attrib C.string_of_big_variant "arabic-form" x
 
   let a_lang = string_attrib "lang"
 
@@ -714,11 +714,11 @@ struct
 
   let a_strokewidth = user_attrib C.string_of_length "stroke-width"
 
-  let a_strokelinecap =
-    user_attrib C.string_of_big_variant "stroke-linecap"
+  let a_strokelinecap x =
+    user_attrib C.string_of_big_variant "stroke-linecap" x
 
-  let a_strokelinejoin =
-    user_attrib C.string_of_big_variant "stroke-linejoin"
+  let a_strokelinejoin x =
+    user_attrib C.string_of_big_variant "stroke-linejoin" x
 
   let a_strokemiterlimit =
     user_attrib C.string_of_number "stroke-miterlimit"

--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -135,7 +135,7 @@ let string_of_paint = function
     (string_of_iri iri) ^" "^ (string_of_paint_whitout_icc b)
   | #paint_whitout_icc as c -> string_of_paint_whitout_icc c
 
-module Make (Xml : Xml_sigs.T) =
+module Make (Xml : Xml_sigs.T with type ('a, 'b) W.ft = ('a -> 'b)) =
 struct
 
   module Xml = Xml

--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -194,12 +194,6 @@ struct
 
   let string_of_lengths = C.string_of_lengths
 
-  let string_of_big_variant :
-    ([< Svg_types.big_variant ], string) C.ft =
-    (C.string_of_big_variant :
-       (Svg_types.big_variant, string) C.ft :>
-       ([< Svg_types.big_variant ], string) C.ft)
-
   (* Custom XML attributes *)
 
   let user_attrib f name v =
@@ -240,8 +234,8 @@ struct
 
   let a_contentstyletype = string_attrib "contentStyleType"
 
-  let a_zoomAndPan x =
-    user_attrib string_of_big_variant "zoomAndSpan" x
+  let a_zoomAndPan =
+    user_attrib C.string_of_big_variant "zoomAndSpan"
 
   let a_xlink_href = string_attrib "xlink:href"
 
@@ -263,8 +257,8 @@ struct
 
   let a_xml_lang = string_attrib "xml:lang"
 
-  let a_xml_space x =
-    user_attrib string_of_big_variant "xml:space" x
+  let a_xml_space =
+    user_attrib C.string_of_big_variant "xml:space"
 
   let a_type = string_attrib "type"
 
@@ -316,36 +310,36 @@ struct
 
   let a_dy_list = user_attrib string_of_lengths "dy"
 
-  let a_lengthadjust x =
-    user_attrib string_of_big_variant "lengthAdjust" x
+  let a_lengthadjust =
+    user_attrib C.string_of_big_variant "lengthAdjust"
 
   let a_textlength = user_attrib string_of_length "textLength"
 
-  let a_text_anchor x =
-    user_attrib string_of_big_variant "text-anchor" x
+  let a_text_anchor =
+    user_attrib C.string_of_big_variant "text-anchor"
 
-  let a_text_decoration x =
-    user_attrib string_of_big_variant "text-decoration" x
+  let a_text_decoration =
+    user_attrib C.string_of_big_variant "text-decoration"
 
-  let a_text_rendering x =
-    user_attrib string_of_big_variant "text-rendering" x
+  let a_text_rendering =
+    user_attrib C.string_of_big_variant "text-rendering"
 
   let a_rotate = user_attrib C.string_of_numbers "rotate"
 
   let a_startoffset = user_attrib string_of_length "startOffset"
 
-  let a_method x =
-    user_attrib string_of_big_variant "method" x
+  let a_method =
+    user_attrib C.string_of_big_variant "method"
 
-  let a_spacing x =
-    user_attrib string_of_big_variant "spacing" x
+  let a_spacing =
+    user_attrib C.string_of_big_variant "spacing"
 
   let a_glyphref = string_attrib "glyphRef"
 
   let a_format = string_attrib "format"
 
-  let a_markerunits x =
-    user_attrib string_of_big_variant "markerUnits" x
+  let a_markerunits =
+    user_attrib C.string_of_big_variant "markerUnits"
 
   let a_refx = user_attrib string_of_coord "refX"
 
@@ -360,17 +354,17 @@ struct
 
   let a_local = string_attrib "local"
 
-  let a_renderingindent x =
-    user_attrib string_of_big_variant "rendering:indent" x
+  let a_renderingindent =
+    user_attrib C.string_of_big_variant "rendering:indent"
 
-  let a_gradientunits x =
-    user_attrib string_of_big_variant "gradientUnits" x
+  let a_gradientunits =
+    user_attrib C.string_of_big_variant "gradientUnits"
 
   let a_gradienttransform =
     user_attrib C.string_of_transforms "gradient:transform"
 
-  let a_spreadmethod x =
-    user_attrib string_of_big_variant "spreadMethod" x
+  let a_spreadmethod =
+    user_attrib C.string_of_big_variant "spreadMethod"
 
   let a_fx = user_attrib string_of_coord "fx"
 
@@ -379,37 +373,37 @@ struct
   let a_offset x =
     user_attrib C.string_of_offset "offset" x
 
-  let a_patternunits x =
-    user_attrib string_of_big_variant "patternUnits" x
+  let a_patternunits =
+    user_attrib C.string_of_big_variant "patternUnits"
 
-  let a_patterncontentunits x =
-    user_attrib string_of_big_variant "patternContentUnits" x
+  let a_patterncontentunits =
+    user_attrib C.string_of_big_variant "patternContentUnits"
 
   let a_patterntransform x =
     user_attrib C.string_of_transforms "patternTransform" x
 
-  let a_clippathunits x =
-    user_attrib string_of_big_variant "clipPathUnits" x
+  let a_clippathunits =
+    user_attrib C.string_of_big_variant "clipPathUnits"
 
-  let a_maskunits x =
-    user_attrib string_of_big_variant "maskUnits" x
+  let a_maskunits =
+    user_attrib C.string_of_big_variant "maskUnits"
 
-  let a_maskcontentunits x =
-    user_attrib string_of_big_variant "maskContentUnits" x
+  let a_maskcontentunits =
+    user_attrib C.string_of_big_variant "maskContentUnits"
 
-  let a_primitiveunits x =
-    user_attrib string_of_big_variant "primitiveUnits" x
+  let a_primitiveunits =
+    user_attrib C.string_of_big_variant "primitiveUnits"
 
-  let a_filterres x =
-    user_attrib C.string_of_number_optional_number "filterResUnits" x
+  let a_filterres =
+    user_attrib C.string_of_number_optional_number "filterResUnits"
 
   let a_result = string_attrib "result"
 
-  let a_in x =
-    user_attrib C.string_of_in_value "in" x
+  let a_in =
+    user_attrib C.string_of_in_value "in"
 
-  let a_in2 x =
-    user_attrib C.string_of_in_value "in2" x
+  let a_in2 =
+    user_attrib C.string_of_in_value "in2"
 
   let a_aizmuth = number_attrib "azimuth"
 
@@ -427,16 +421,16 @@ struct
 
   let a_limitingconeangle = number_attrib "limitingConeAngle"
 
-  let a_mode x =
-    user_attrib string_of_big_variant "mode" x
+  let a_mode =
+    user_attrib C.string_of_big_variant "mode"
 
-  let a_typefecolor x =
-    user_attrib string_of_big_variant "type" x
+  let a_typefecolor =
+    user_attrib C.string_of_big_variant "type"
 
   let a_values = user_attrib C.string_of_numbers "values"
 
-  let a_transferttype x =
-    user_attrib string_of_big_variant "type" x
+  let a_transferttype =
+    user_attrib C.string_of_big_variant "type"
 
   let a_tablevalues = user_attrib C.string_of_numbers "tableValues"
 
@@ -448,8 +442,8 @@ struct
 
   let a_offsettransfer = user_attrib C.string_of_number "offset"
 
-  let a_operator x =
-    user_attrib string_of_big_variant "operator" x
+  let a_operator =
+    user_attrib C.string_of_big_variant "operator"
 
   let a_k1 = user_attrib C.string_of_number "k1"
 
@@ -474,8 +468,8 @@ struct
 
   let a_targetY = user_attrib C.string_of_int "targetY"
 
-  let a_edgemode x =
-    user_attrib string_of_big_variant "targetY" x
+  let a_edgemode =
+    user_attrib C.string_of_big_variant "targetY"
 
   let a_preservealpha = user_attrib C.string_of_bool "targetY"
 
@@ -486,17 +480,17 @@ struct
 
   let a_scale = user_attrib C.string_of_number "scale"
 
-  let a_xchannelselector x =
-    user_attrib string_of_big_variant "xChannelSelector" x
+  let a_xchannelselector =
+    user_attrib C.string_of_big_variant "xChannelSelector"
 
-  let a_ychannelselector x =
-    user_attrib string_of_big_variant "yChannelSelector" x
+  let a_ychannelselector =
+    user_attrib C.string_of_big_variant "yChannelSelector"
 
   let a_stddeviation =
     user_attrib C.string_of_number_optional_number "stdDeviation"
 
-  let a_operatormorphology x =
-    user_attrib string_of_big_variant "operatorMorphology" x
+  let a_operatormorphology =
+    user_attrib C.string_of_big_variant "operatorMorphology"
 
   let a_radius = user_attrib C.string_of_number_optional_number "radius"
 
@@ -507,17 +501,17 @@ struct
 
   let a_seed = user_attrib C.string_of_number "seed"
 
-  let a_stitchtiles x =
-    user_attrib string_of_big_variant "stitchTiles" x
+  let a_stitchtiles =
+    user_attrib C.string_of_big_variant "stitchTiles"
 
-  let a_stitchtype x =
-    user_attrib string_of_big_variant "typeStitch" x
+  let a_stitchtype =
+    user_attrib C.string_of_big_variant "typeStitch"
 
-  let a_xlinkshow x =
-    user_attrib string_of_big_variant "xlink:show" x
+  let a_xlinkshow =
+    user_attrib C.string_of_big_variant "xlink:show"
 
-  let a_xlinkactuate x =
-    user_attrib string_of_big_variant "xlink:actuate" x
+  let a_xlinkactuate =
+    user_attrib C.string_of_big_variant "xlink:actuate"
 
   let a_target = string_attrib "xlink:target"
 
@@ -525,8 +519,8 @@ struct
 
   let a_attributename = string_attrib "attributeName"
 
-  let a_attributetype x =
-    user_attrib string_of_big_variant "attributeType" x
+  let a_attributetype =
+    user_attrib C.string_of_big_variant "attributeType"
 
   let a_begin = string_attrib "begin"
 
@@ -536,8 +530,8 @@ struct
 
   let a_max = string_attrib "max"
 
-  let a_restart x =
-    user_attrib string_of_big_variant "restart" x
+  let a_restart =
+    user_attrib C.string_of_big_variant "restart"
 
   let a_repeatcount = string_attrib "repeatCount"
 
@@ -545,11 +539,11 @@ struct
 
   let a_fill = user_attrib C.string_of_paint "fill"
 
-  let a_fill_animation x =
-    user_attrib string_of_big_variant "fill" x
+  let a_fill_animation =
+    user_attrib C.string_of_big_variant "fill"
 
-  let a_calcmode x =
-    user_attrib string_of_big_variant "calcMode" x
+  let a_calcmode =
+    user_attrib C.string_of_big_variant "calcMode"
 
   let a_values_anim = Xml.comma_sep_attrib "values"
 
@@ -563,18 +557,18 @@ struct
 
   let a_by = string_attrib "by"
 
-  let a_additive x =
-    user_attrib string_of_big_variant "additive" x
+  let a_additive =
+    user_attrib C.string_of_big_variant "additive"
 
-  let a_accumulate x =
-    user_attrib string_of_big_variant "accumulate" x
+  let a_accumulate =
+    user_attrib C.string_of_big_variant "accumulate"
 
   let a_keypoints = user_attrib C.string_of_numbers_semicolon "keyPoints"
 
   let a_path = string_attrib "path"
 
-  let a_typeanimatecolor x =
-    user_attrib string_of_big_variant "type" x
+  let a_typeanimatecolor =
+    user_attrib C.string_of_big_variant "type"
 
   let a_horiz_origin_x = user_attrib C.string_of_number "horiz-origin-x"
 
@@ -592,11 +586,11 @@ struct
 
   let a_glyphname = string_attrib "glyphname"
 
-  let a_orientation x =
-    user_attrib string_of_big_variant "orientation" x
+  let a_orientation =
+    user_attrib C.string_of_big_variant "orientation"
 
-  let a_arabicform x =
-    user_attrib string_of_big_variant "arabic-form" x
+  let a_arabicform =
+    user_attrib C.string_of_big_variant "arabic-form"
 
   let a_lang = string_attrib "lang"
 
@@ -720,11 +714,11 @@ struct
 
   let a_strokewidth = user_attrib C.string_of_length "stroke-width"
 
-  let a_strokelinecap x =
-    user_attrib string_of_big_variant "stroke-linecap" x
+  let a_strokelinecap =
+    user_attrib C.string_of_big_variant "stroke-linecap"
 
-  let a_strokelinejoin x =
-    user_attrib string_of_big_variant "stroke-linejoin" x
+  let a_strokelinejoin =
+    user_attrib C.string_of_big_variant "stroke-linejoin"
 
   let a_strokemiterlimit =
     user_attrib C.string_of_number "stroke-miterlimit"

--- a/lib/svg_f.mli
+++ b/lib/svg_f.mli
@@ -84,3 +84,12 @@ module Make(Xml : Xml_sigs.T with type ('a, 'b) W.ft = ('a -> 'b))
   : Svg_sigs.Make(Xml).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib
+
+module Conv : Svg_sigs.Conv with type (-'a, 'b) ft = 'a -> 'b
+
+module Make'
+    (Xml : Xml_sigs.T)
+    (C : Svg_sigs.Conv with type (-'a, 'b) ft = ('a, 'b) Xml.W.ft)
+  : Svg_sigs.Make(Xml).T
+    with type +'a elt = Xml.elt
+     and type +'a attrib = Xml.attrib

--- a/lib/svg_f.mli
+++ b/lib/svg_f.mli
@@ -85,11 +85,13 @@ module Make(Xml : Xml_sigs.T with type ('a, 'b) W.ft = ('a -> 'b))
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib
 
-module Conv : Svg_sigs.Conv with type (-'a, 'b) ft = 'a -> 'b
+module Wrapped_functions :
+  Svg_sigs.Wrapped_functions with type (-'a, 'b) ft = 'a -> 'b
 
-module Make'
+module Make_with_wrapped_functions
     (Xml : Xml_sigs.T)
-    (C : Svg_sigs.Conv with type (-'a, 'b) ft = ('a, 'b) Xml.W.ft)
+    (C : Svg_sigs.Wrapped_functions
+     with type (-'a, 'b) ft = ('a, 'b) Xml.W.ft)
   : Svg_sigs.Make(Xml).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib

--- a/lib/svg_f.mli
+++ b/lib/svg_f.mli
@@ -80,7 +80,7 @@ val string_of_transform : transform -> string
 val string_of_transforms : transforms -> string
 *)
 
-module Make(Xml : Xml_sigs.T)
+module Make(Xml : Xml_sigs.T with type ('a, 'b) W.ft = ('a -> 'b))
   : Svg_sigs.Make(Xml).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -892,9 +892,6 @@ end
 
 module type NoWrap = T with module Xml.W = Xml_wrap.NoWrap
 
-(** {2 Signature functors} *)
-(** See {% <<a_manual chapter="functors"|the manual of the functorial interface>> %}. *)
-
 module type Wrapped_functions = sig
 
   type (-'a, 'b) ft
@@ -943,6 +940,9 @@ module type Wrapped_functions = sig
   val string_of_transforms : (Svg_types.transforms, string) ft
 
 end
+
+(** {2 Signature functors} *)
+(** See {% <<a_manual chapter="functors"|the manual of the functorial interface>> %}. *)
 
 (** Signature functor for {!Svg_f.Make}. *)
 module Make (Xml : Xml_sigs.T) : sig

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -895,7 +895,7 @@ module type NoWrap = T with module Xml.W = Xml_wrap.NoWrap
 (** {2 Signature functors} *)
 (** See {% <<a_manual chapter="functors"|the manual of the functorial interface>> %}. *)
 
-module type Conv = sig
+module type Wrapped_functions = sig
 
   type (-'a, 'b) ft
 

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -904,7 +904,7 @@ module type Conv = sig
 
   val string_of_bool : (bool, string) ft
 
-  val string_of_big_variant : (Svg_types.big_variant, string) ft
+  val string_of_big_variant : ([< Svg_types.big_variant], string) ft
 
   val string_of_coords : (Svg_types.coords, string) ft
 
@@ -934,7 +934,7 @@ module type Conv = sig
 
   val string_of_orient : ([< Svg_types.orient], string) ft
 
-  val string_of_paint : (Svg_types.paint, string) ft
+  val string_of_paint : ([< Svg_types.paint], string) ft
 
   val string_of_strokedasharray : (Svg_types.lengths, string) ft
 

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -895,6 +895,55 @@ module type NoWrap = T with module Xml.W = Xml_wrap.NoWrap
 (** {2 Signature functors} *)
 (** See {% <<a_manual chapter="functors"|the manual of the functorial interface>> %}. *)
 
+module type Conv = sig
+
+  type (-'a, 'b) ft
+
+  val string_of_alignment_baseline :
+    ([< Svg_types.alignment_baseline], string) ft
+
+  val string_of_bool : (bool, string) ft
+
+  val string_of_big_variant : (Svg_types.big_variant, string) ft
+
+  val string_of_coords : (Svg_types.coords, string) ft
+
+  val string_of_dominant_baseline :
+    ([< Svg_types.dominant_baseline], string) ft
+
+  val string_of_fourfloats : (float * float * float * float, string) ft
+
+  val string_of_in_value : ([< Svg_types.in_value], string) ft
+
+  val string_of_int : (int, string) ft
+
+  val string_of_length : (Svg_types.Unit.length, string) ft
+
+  val string_of_lengths : (Svg_types.lengths, string) ft
+
+  val string_of_number : (float, string) ft
+
+  val string_of_number_optional_number :
+    (float * float option, string) ft
+
+  val string_of_numbers : (float list, string) ft
+
+  val string_of_numbers_semicolon : (float list, string) ft
+
+  val string_of_offset : ([< Svg_types.offset], string) ft
+
+  val string_of_orient : ([< Svg_types.orient], string) ft
+
+  val string_of_paint : (Svg_types.paint, string) ft
+
+  val string_of_strokedasharray : (Svg_types.lengths, string) ft
+
+  val string_of_transform : (Svg_types.transform, string) ft
+
+  val string_of_transforms : (Svg_types.transforms, string) ft
+
+end
+
 (** Signature functor for {!Svg_f.Make}. *)
 module Make (Xml : Xml_sigs.T) : sig
 

--- a/lib/svg_types.mli
+++ b/lib/svg_types.mli
@@ -1913,3 +1913,149 @@ type foreignobject_attr =
     | `Width
     | `Height
   ]
+
+type alignment_baseline =
+  [ `After_edge
+  | `Alphabetic
+  | `Auto
+  | `Baseline
+  | `Before_edge
+  | `Central
+  | `Hanging
+  | `Ideographic
+  | `Inherit
+  | `Mathematical
+  | `Middle
+  | `Text_after_edge
+  | `Text_before_edge ]
+
+type dominant_baseline =
+  [ `Auto
+  | `Use_script
+  | `No_change
+  | `Reset_size
+  | `Ideographic
+  | `Alphabetic
+  | `Hanging
+  | `Mathematical
+  | `Central
+  | `Middle
+  | `Text_after_edge
+  | `Text_before_edge
+  | `Inherit
+  ]
+
+type in_value =
+  [ `SourceGraphic
+  | `SourceAlpha
+  | `BackgroundImage
+  | `BackgroundAlpha
+  | `FillPaint
+  | `StrokePaint
+  | `Ref of string ]
+
+type offset =
+  [ `Number of float
+  | `Percentage of int ]
+
+type orient =
+  [ `Auto
+  | `Angle of Unit.angle ]
+
+type big_variant =
+  [ `A
+  | `Absolute_colorimetric
+  | `Align
+  | `Always
+  | `Atop
+  | `Arithmetic
+  | `Auto
+  | `B
+  | `Bever
+  | `Blink
+  | `Butt
+  | `CSS
+  | `Darken
+  | `Default
+  | `Dilate
+  | `Disable
+  | `Discrete
+  | `Duplicate
+  | `End
+  | `Erode
+  | `Exact
+  | `FractalNoise
+  | `Freeze
+  | `HueRotate
+  | `G
+  | `Gamma
+  | `GeometricPrecision
+  | `H
+  | `Identity
+  | `In
+  | `Inherit
+  | `Initial
+  | `Isolated
+  | `Lighten
+  | `Line_through
+  | `Linear
+  | `LuminanceToAlpha
+  | `Magnify
+  | `Matrix
+  | `Medial
+  | `Middle
+  | `Miter
+  | `Multiply
+  | `Never
+  | `New
+  | `None
+  | `Normal
+  | `NoStitch
+  | `ObjectBoundingBox
+  | `OnLoad
+  | `OnRequest
+  | `OptimizeLegibility
+  | `OptimizeSpeed
+  | `Other
+  | `Out
+  | `Over
+  | `Overline
+  | `Paced
+  | `Pad
+  | `Perceptual
+  | `Preserve
+  | `R
+  | `Reflect
+  | `Remove
+  | `Repeat
+  | `Replace
+  | `Relative_colorimetric
+  | `Rotate
+  | `Round
+  | `Saturate
+  | `Saturation
+  | `Scale
+  | `Screen
+  | `SkewX
+  | `SkewY
+  | `Spacing
+  | `SpacingAndGlyphs
+  | `Spline
+  | `Square
+  | `Start
+  | `Stitch
+  | `Stretch
+  | `StrokeWidth
+  | `Sum
+  | `Table
+  | `Terminal
+  | `Translate
+  | `Turbulence
+  | `Underline
+  | `UserSpaceOnUse
+  | `V
+  | `WhenNotActive
+  | `Wrap
+  | `XML
+  | `Xor
+  ]

--- a/lib/xml_wrap.ml
+++ b/lib/xml_wrap.ml
@@ -21,7 +21,7 @@ module type T = sig
   type 'a t
   val return : 'a -> 'a t
 
-  type ('a, 'b) ft
+  type (-'a, 'b) ft
   val fmap : ('a, 'b) ft -> 'a t -> 'b t
 
   type 'a tlist
@@ -35,12 +35,12 @@ end
 module type NoWrap =
   T with type 'a t = 'a
      and type 'a tlist = 'a list
-     and type ('a, 'b) ft = 'a -> 'b
+     and type (-'a, 'b) ft = 'a -> 'b
 
 module NoWrap = struct
   type 'a t = 'a
   type 'a tlist = 'a list
-  type ('a, 'b) ft = 'a -> 'b
+  type (-'a, 'b) ft = 'a -> 'b
   external return : 'a -> 'a = "%identity"
   let fmap f :  'a t -> 'b t = f
 

--- a/lib/xml_wrap.ml
+++ b/lib/xml_wrap.ml
@@ -17,26 +17,30 @@
  * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
 *)
 
-
 module type T = sig
   type 'a t
-  type 'a tlist
   val return : 'a -> 'a t
-  val fmap : ('a -> 'b) -> 'a t -> 'b t
 
+  type ('a, 'b) ft
+  val fmap : ('a, 'b) ft -> 'a t -> 'b t
+
+  type 'a tlist
   val nil : unit -> 'a tlist
   val singleton : 'a t -> 'a tlist
   val cons : 'a t -> 'a tlist -> 'a tlist
   val append : 'a tlist -> 'a tlist -> 'a tlist
-  val map : ('a -> 'b) -> 'a tlist -> 'b tlist
+  val map : ('a, 'b) ft -> 'a tlist -> 'b tlist
 end
 
 module type NoWrap =
-  T with type 'a t = 'a and type 'a tlist = 'a list
+  T with type 'a t = 'a
+     and type 'a tlist = 'a list
+     and type ('a, 'b) ft = 'a -> 'b
 
 module NoWrap = struct
   type 'a t = 'a
   type 'a tlist = 'a list
+  type ('a, 'b) ft = 'a -> 'b
   external return : 'a -> 'a = "%identity"
   let fmap f :  'a t -> 'b t = f
 

--- a/lib/xml_wrap.mli
+++ b/lib/xml_wrap.mli
@@ -21,7 +21,7 @@ module type T = sig
   type 'a t
   val return : 'a -> 'a t
 
-  type ('a, 'b) ft
+  type (-'a, 'b) ft
   val fmap : ('a, 'b) ft -> 'a t -> 'b t
 
   type 'a tlist
@@ -35,6 +35,6 @@ end
 module type NoWrap =
   T with type 'a t = 'a
      and type 'a tlist = 'a list
-     and type ('a, 'b) ft = 'a -> 'b
+     and type (-'a, 'b) ft = 'a -> 'b
 
 module NoWrap : NoWrap

--- a/lib/xml_wrap.mli
+++ b/lib/xml_wrap.mli
@@ -19,18 +19,22 @@
 
 module type T = sig
   type 'a t
-  type 'a tlist
   val return : 'a -> 'a t
-  val fmap : ('a -> 'b) -> 'a t -> 'b t
 
+  type ('a, 'b) ft
+  val fmap : ('a, 'b) ft -> 'a t -> 'b t
+
+  type 'a tlist
   val nil : unit -> 'a tlist
   val singleton : 'a t -> 'a tlist
   val cons : 'a t -> 'a tlist -> 'a tlist
   val append : 'a tlist -> 'a tlist -> 'a tlist
-  val map : ('a -> 'b ) -> 'a tlist -> 'b tlist
+  val map : ('a, 'b) ft -> 'a tlist -> 'b tlist
 end
 
 module type NoWrap =
-  T with type 'a t = 'a and type 'a tlist = 'a list
+  T with type 'a t = 'a
+     and type 'a tlist = 'a list
+     and type ('a, 'b) ft = 'a -> 'b
 
 module NoWrap : NoWrap


### PR DESCRIPTION
The `sharedreactcontent` branch provides the changes that we need in order to implement an `R` module for Eliom shared values.

The main points are:

* `Xml_wrap.T'` adds a type constructor `ft` to `Xml_wrap.T`. This is in order to accommodate
  shared functions for operating on shared values.
* A signature `Conv` contains instances of `ft` for all operations on wrapped elements that the
  functor performs. This is needed because we cannot simply inject server-side functions.
* Our use of shadow types becomes "customizable". The functor receives types `u` and `'a s` related
  by operations `shadow : u -> 'a s` and `unshadow : 'a s -> u` . `'a s` becomes the type of the resulting
  HTML elements. This is in order to achieve type equalities between different functor invocations (in
  Eliom) that would be hard to achieve otherwise.

The corresponding Eliom branch is also called `sharedreactcontent`.

Concerns? Suggestions? I know that the implementation is rough and incomplete, e.g., there is no SVG support yet. Hopefully an early pull request is a good format for discussion on this.