### PR TITLE
Add <main> tag

### DIFF
--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -661,6 +661,8 @@ struct
 
   let aside = star "aside"
 
+  let main = star "main"
+
   let video_audio name ?src ?srcs ?(a = []) elts =
     let a =
       match src with

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -603,6 +603,9 @@ module type T = sig
   val aside :
     ([< | aside_attrib], [< | aside_content_fun], [> | aside]) star
 
+  val main :
+    ([< | main_attrib], [< | main_content_fun], [> | main]) star
+
   (** {2 Grouping content} *)
 
   val p : ([< | p_attrib], [< | p_content_fun], [> | p]) star

--- a/lib/html5_types.mli
+++ b/lib/html5_types.mli
@@ -922,6 +922,7 @@ type core_flow5_without_interactive =
     | `Form
     | `Figure
     | `Dl
+    | `Main
   ]
 
 type core_flow5_without_noscript =
@@ -939,6 +940,7 @@ type core_flow5_without_noscript =
     | `Figure
     | `Dl
     | `Details
+    | `Main
   ]
 type core_flow5_without_media =
   [
@@ -955,7 +957,7 @@ type core_flow5_without_media =
     | `Figure
     | `Dl
     | `Details
-
+    | `Main
   ]
 
 type flow5_without_interactive =
@@ -998,6 +1000,7 @@ type flow5_without_table =
     | `Figure
     | `Dl
     | `Details
+    | `Main
     | (flow5_without_interactive, flow5_without_noscript, flow5,
        flow5_without_media) transparent
   ]
@@ -1022,6 +1025,7 @@ type flow5_without_interactive_header_footer =
     | `Form
     | `Figure
     | `Dl
+    | `Main
     | (flow5_without_noscript, flow5, flow5_without_media)
         transparent_without_interactive
   ]
@@ -1047,6 +1051,7 @@ type flow5_without_header_footer =
     | `Figure
     | `Dl
     | `Details
+    | `Main
     | (flow5_without_interactive_header_footer,
        flow5_without_noscript, flow5,
        flow5_without_media) transparent
@@ -1092,6 +1097,7 @@ type flow5_without_form =
     | `Figure
     | `Dl
     | `Details
+    | `Main
     | (flow5_without_interactive, flow5_without_noscript, flow5,
        flow5_without_media) transparent
   ]
@@ -1114,6 +1120,7 @@ type flow5_without_sectioning_heading_header_footer_address =
     | `Figure
     | `Dl
     | `Details
+    | `Main
     | (flow5_without_interactive, flow5_without_noscript, flow5,
        flow5_without_media) transparent
   ]

--- a/lib/html5_types.mli
+++ b/lib/html5_types.mli
@@ -905,6 +905,7 @@ type core_flow5 =
     | `Figure
     | `Dl
     | `Details
+    | `Main
   ]
 
 type core_flow5_without_interactive =
@@ -1320,6 +1321,15 @@ type aside_content = [ | flow5 ]
 type aside_content_fun = [ | flow5 ]
 
 type aside_attrib = [ | common ]
+
+(* NAME: main, KIND: star, TYPE: [= common ], [= flow5 ], [=`Main], ARG: [= flow5 ], ATTRIB:  OUT: [=`Main] *)
+type main = [ | `Main ]
+
+type main_content = [ | flow5 ]
+
+type main_content_fun = [ | flow5 ]
+
+type main_attrib = [ | common ]
 
 (* NAME: p, KIND: star, TYPE: [= common ], [=phrasing ], [=`P], ARG: [=phrasing ], ATTRIB:  OUT: [=`P] *)
 type p = [ | `P ]


### PR DESCRIPTION
Hi,
This is a patch proposal to add the `<main>` tag. I am really not sure if the `core_flow5` type is the best place for this tag. The HTML5 spec specifies two restrictions: `<main>` must not be a descendent of an `<article>`, `<aside>`, `<footer>`, `<header>`, or `<nav>` element and authors must not include more than one `<main>` element in a document. But the living HTML standard removes these two restrictions.

ref. :  https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main and https://html.spec.whatwg.org/multipage/semantics.html#the-main-element