### PR TITLE
Work around issue #81

### DIFF
--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -1055,11 +1055,11 @@ module Wrapped_functions = struct
   let string_of_srcset l =
     let f = function
     | `Url url ->
-      Xml.string_of_uri url
+      url
     | `Url_width (url, v) ->
-      Printf.sprintf "%s %sw" (Xml.string_of_uri url) (string_of_number v)
+      Printf.sprintf "%s %sw" url (string_of_number v)
     | `Url_pixel (url, v) ->
-      Printf.sprintf "%s %sx" (Xml.string_of_uri url) (Xml_print.string_of_number v)
+      Printf.sprintf "%s %sx" url (Xml_print.string_of_number v)
     in
     String.concat ", " (List.map f l)
 


### PR DESCRIPTION
This is not a long-term solution, because it exploits the accidental type equality between URIs and strings. It suffices to keep Eliom et al. happy for now.