### PR TITLE
Add sizes attribute in <img> tag

### DIFF
--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -102,6 +102,8 @@ struct
   let srcset_attrib name x =
     user_attrib C.string_of_srcset name x
 
+  let src_sizes_attrib = comma_sep_attrib "sizes"
+
   (* Core: *)
   let a_class = space_sep_attrib "class"
 
@@ -398,6 +400,8 @@ struct
   let a_srclang = string_attrib "xml:lang"
 
   let a_srcset = srcset_attrib "srcset"
+
+  let a_src_sizes = comma_sep_attrib "sizes"
 
   let a_start = int_attrib "start"
 

--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -102,7 +102,7 @@ struct
   let srcset_attrib name x =
     user_attrib C.string_of_srcset name x
 
-  let src_sizes_attrib = comma_sep_attrib "sizes"
+  let img_sizes_attrib = comma_sep_attrib "sizes"
 
   (* Core: *)
   let a_class = space_sep_attrib "class"
@@ -401,7 +401,7 @@ struct
 
   let a_srcset = srcset_attrib "srcset"
 
-  let a_src_sizes = comma_sep_attrib "sizes"
+  let a_img_sizes = comma_sep_attrib "sizes"
 
   let a_start = int_attrib "start"
 

--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -102,8 +102,6 @@ struct
   let srcset_attrib name x =
     user_attrib C.string_of_srcset name x
 
-  let img_sizes_attrib = comma_sep_attrib "sizes"
-
   (* Core: *)
   let a_class = space_sep_attrib "class"
 

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -160,7 +160,7 @@ module type T = sig
 
   val a_srcset : image_candidate list wrap -> [> | `Srcset] attrib
 
-  val a_src_sizes : text list wrap -> [> | `Src_sizes] attrib
+  val a_img_sizes : text list wrap -> [> | `Img_sizes] attrib
 
   val a_start : number wrap -> [> | `Start] attrib
 

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -160,6 +160,8 @@ module type T = sig
 
   val a_srcset : image_candidate list wrap -> [> | `Srcset] attrib
 
+  val a_src_sizes : text list wrap -> [> | `Src_sizes] attrib
+
   val a_start : number wrap -> [> | `Start] attrib
 
   val a_step : float_number option wrap -> [> | `Step] attrib

--- a/lib/html5_types.mli
+++ b/lib/html5_types.mli
@@ -1765,7 +1765,7 @@ type img = [ `Img ]
 type img_interactive = [ `Img | `Img_interactive ]
 type img_content = notag
 type img_content_fun = notag
-type img_attrib = [ | common | `Height | `Ismap | `Width | `Srcset | `Src_sizes]
+type img_attrib = [ | common | `Height | `Ismap | `Width | `Srcset | `Img_sizes]
 
 (* Attributes used by audio and video. *)
 type media_attrib =

--- a/lib/html5_types.mli
+++ b/lib/html5_types.mli
@@ -1765,7 +1765,7 @@ type img = [ `Img ]
 type img_interactive = [ `Img | `Img_interactive ]
 type img_content = notag
 type img_content_fun = notag
-type img_attrib = [ | common | `Height | `Ismap | `Width | `Srcset ]
+type img_attrib = [ | common | `Height | `Ismap | `Width | `Srcset | `Src_sizes]
 
 (* Attributes used by audio and video. *)
 type media_attrib =


### PR DESCRIPTION
https://www.w3.org/html/wg/drafts/html/master/semantics.html#attr-img-sizes
https://www.smashingmagazine.com/2014/05/responsive-images-done-right-guide-picture-srcset/

As this attribute can be quite complex (for instance: `(min-width: 36em) calc(.333 * (100vw - 12em)), 100vw`), a string list seems a good realistic choice.