### PR TITLE
Fix inconsistent naming and typos.

### DIFF
--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -848,12 +848,12 @@ module Wrapped_functions = struct
   type ('a, 'b) ft = 'a -> 'b
 
   let string_of_sandbox_token = function
-    | `AllowForms -> "allow-forms"
-    | `AllowPointerLock -> "allow-pointer-lock"
-    | `AllowPopups -> "allow-popups"
-    | `AllowTopNavigation -> "allow-top-navigation"
-    | `AllowSameOrigin -> "allow-same-origin"
-    | `AllowScript -> "allow-script"
+    | `Allow_forms -> "allow-forms"
+    | `Allow_pointer_lock -> "allow-pointer-lock"
+    | `Allow_popups -> "allow-popups"
+    | `Allow_top_navigation -> "allow-top-navigation"
+    | `Allow_same_origin -> "allow-same-origin"
+    | `Allow_script -> "allow-script"
 
   let string_of_multilength = function
     | `Percent p -> (string_of_int p) ^ "%"

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -135,15 +135,7 @@ module type T = sig
 
   val a_reversed : [< | `Reversed] wrap -> [> | `Reversed] attrib
 
-  val a_sandbox :
-    [<
-     | `AllowSameOrigin
-     | `AllowForms
-     | `AllowScript
-     | `AllowPointerLock
-     | `AllowPopups
-     | `AllowTopNavigation ] list wrap ->
-    [> | `Sandbox] attrib
+  val a_sandbox : [< | sandbox_token ] list wrap -> [> | `Sandbox] attrib
 
   val a_spellcheck : bool wrap -> [> | `Spellcheck] attrib
 

--- a/lib/html5_types.mli
+++ b/lib/html5_types.mli
@@ -2322,12 +2322,12 @@ type big_variant =
   ]
 
 type sandbox_token =
-  [ `AllowForms
-  | `AllowPointerLock
-  | `AllowPopups
-  | `AllowTopNavigation
-  | `AllowSameOrigin
-  | `AllowScript ]
+  [ `Allow_forms
+  | `Allow_pointer_lock
+  | `Allow_popups
+  | `Allow_top_navigation
+  | `Allow_same_origin
+  | `Allow_script ]
 
 
 type input_type =

--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -210,14 +210,14 @@ struct
 
   let metadata ?a children = Xml.node ?a "metadata" children
 
-  let foreignobject ?a children = Xml.node ?a "foreignObject" children
+  let foreignObject ?a children = Xml.node ?a "foreignObject" children
 
   let pcdata s = Xml.pcdata s
 
   (* generated *)
   let a_version = string_attrib "version"
 
-  let a_baseprofile = string_attrib "baseProfile"
+  let a_baseProfile = string_attrib "baseProfile"
 
   let a_x = user_attrib string_of_coord "x"
 
@@ -227,29 +227,29 @@ struct
 
   let a_height = user_attrib string_of_length "height"
 
-  let a_preserveaspectratio =
+  let a_preserveAspectRatio =
     string_attrib "preserveAspectRatio"
 
-  let a_contentscripttype =
+  let a_contentScriptType =
     string_attrib "contentScriptType"
 
-  let a_contentstyletype = string_attrib "contentStyleType"
+  let a_contentStyleType = string_attrib "contentStyleType"
 
   let a_zoomAndPan x =
     user_attrib C.string_of_big_variant "zoomAndSpan" x
 
   let a_xlink_href = string_attrib "xlink:href"
 
-  let a_requiredfeatures =
+  let a_requiredFeatures =
     Xml.space_sep_attrib "requiredFeatures"
 
-  let a_requiredextensions =
+  let a_requiredExtensions =
     Xml.space_sep_attrib "requiredExtension"
 
-  let a_systemlanguage =
+  let a_systemLanguage =
     Xml.comma_sep_attrib "systemLanguage"
 
-  let a_externalressourcesrequired =
+  let a_externalRessourcesRequired =
     user_attrib C.string_of_bool "externalRessourcesRequired"
 
   let a_id = string_attrib "id"
@@ -273,11 +273,11 @@ struct
 
   let a_transform = user_attrib C.string_of_transform "transform"
 
-  let a_viewbox = user_attrib C.string_of_fourfloats "viewBox"
+  let a_viewBox = user_attrib C.string_of_fourfloats "viewBox"
 
   let a_d = string_attrib "d"
 
-  let a_pathlength = number_attrib "pathLength"
+  let a_pathLength = number_attrib "pathLength"
 
   let a_rx = user_attrib string_of_length "rx"
 
@@ -311,10 +311,10 @@ struct
 
   let a_dy_list = user_attrib string_of_lengths "dy"
 
-  let a_lengthadjust x =
+  let a_lengthAdjust x =
     user_attrib C.string_of_big_variant "lengthAdjust" x
 
-  let a_textlength = user_attrib string_of_length "textLength"
+  let a_textLength = user_attrib string_of_length "textLength"
 
   let a_text_anchor x =
     user_attrib C.string_of_big_variant "text-anchor" x
@@ -327,7 +327,7 @@ struct
 
   let a_rotate = user_attrib C.string_of_numbers "rotate"
 
-  let a_startoffset = user_attrib string_of_length "startOffset"
+  let a_startOffset = user_attrib string_of_length "startOffset"
 
   let a_method x =
     user_attrib C.string_of_big_variant "method" x
@@ -335,36 +335,36 @@ struct
   let a_spacing x =
     user_attrib C.string_of_big_variant "spacing" x
 
-  let a_glyphref = string_attrib "glyphRef"
+  let a_glyphRef = string_attrib "glyphRef"
 
   let a_format = string_attrib "format"
 
-  let a_markerunits x =
+  let a_markerUnits x =
     user_attrib C.string_of_big_variant "markerUnits" x
 
-  let a_refx = user_attrib string_of_coord "refX"
+  let a_refX = user_attrib string_of_coord "refX"
 
-  let a_refy = user_attrib string_of_coord "refY"
+  let a_refY = user_attrib string_of_coord "refY"
 
-  let a_markerwidth = user_attrib string_of_length "markerWidth"
+  let a_markerWidth = user_attrib string_of_length "markerWidth"
 
-  let a_markerheight = user_attrib string_of_length "markerHeight"
+  let a_markerHeight = user_attrib string_of_length "markerHeight"
 
   let a_orient x =
     user_attrib C.string_of_orient "orient" x
 
   let a_local = string_attrib "local"
 
-  let a_renderingindent x =
-    user_attrib C.string_of_big_variant "rendering:indent" x
+  let a_rendering_intent x =
+    user_attrib C.string_of_big_variant "rendering-intent" x
 
-  let a_gradientunits x =
+  let a_gradientUnits x =
     user_attrib C.string_of_big_variant "gradientUnits" x
 
-  let a_gradienttransform =
-    user_attrib C.string_of_transforms "gradient:transform"
+  let a_gradientTransform =
+    user_attrib C.string_of_transforms "gradientTransform"
 
-  let a_spreadmethod x =
+  let a_spreadMethod x =
     user_attrib C.string_of_big_variant "spreadMethod" x
 
   let a_fx = user_attrib string_of_coord "fx"
@@ -374,28 +374,28 @@ struct
   let a_offset x =
     user_attrib C.string_of_offset "offset" x
 
-  let a_patternunits x =
+  let a_patternUnits x =
     user_attrib C.string_of_big_variant "patternUnits" x
 
-  let a_patterncontentunits x =
+  let a_patternContentUnits x =
     user_attrib C.string_of_big_variant "patternContentUnits" x
 
-  let a_patterntransform x =
+  let a_patternTransform x =
     user_attrib C.string_of_transforms "patternTransform" x
 
-  let a_clippathunits x =
+  let a_clipPathUnits x =
     user_attrib C.string_of_big_variant "clipPathUnits" x
 
-  let a_maskunits x =
+  let a_maskUnits x =
     user_attrib C.string_of_big_variant "maskUnits" x
 
-  let a_maskcontentunits x =
+  let a_maskContentUnits x =
     user_attrib C.string_of_big_variant "maskContentUnits" x
 
-  let a_primitiveunits x =
+  let a_primitiveUnits x =
     user_attrib C.string_of_big_variant "primitiveUnits" x
 
-  let a_filterres =
+  let a_filterRes =
     user_attrib C.string_of_number_optional_number "filterResUnits"
 
   let a_result = string_attrib "result"
@@ -406,34 +406,34 @@ struct
   let a_in2 x =
     user_attrib C.string_of_in_value "in2" x
 
-  let a_aizmuth = number_attrib "azimuth"
+  let a_azimuth = number_attrib "azimuth"
 
   let a_elevation = number_attrib "elevation"
 
-  let a_pointatx = number_attrib "pointsAtX"
+  let a_pointsAtX = number_attrib "pointsAtX"
 
-  let a_pointaty = number_attrib "pointsAtY"
+  let a_pointsAtY = number_attrib "pointsAtY"
 
-  let a_pointatz = number_attrib "pointsAtZ"
+  let a_pointsAtZ = number_attrib "pointsAtZ"
 
-  let a_specularexponent = number_attrib "specularExponent"
+  let a_specularExponent = number_attrib "specularExponent"
 
-  let a_specularconstant = number_attrib "specularConstant"
+  let a_specularConstant = number_attrib "specularConstant"
 
-  let a_limitingconeangle = number_attrib "limitingConeAngle"
+  let a_limitingConeAngle = number_attrib "limitingConeAngle"
 
   let a_mode x =
     user_attrib C.string_of_big_variant "mode" x
 
-  let a_typefecolor x =
+  let a_feColorMatrix_type x =
     user_attrib C.string_of_big_variant "type" x
 
   let a_values = user_attrib C.string_of_numbers "values"
 
-  let a_transferttype x =
+  let a_type_transfer x =
     user_attrib C.string_of_big_variant "type" x
 
-  let a_tablevalues = user_attrib C.string_of_numbers "tableValues"
+  let a_tableValues = user_attrib C.string_of_numbers "tableValues"
 
   let a_intercept = user_attrib C.string_of_number "intercept"
 
@@ -441,7 +441,7 @@ struct
 
   let a_exponent = user_attrib C.string_of_number "exponent"
 
-  let a_offsettransfer = user_attrib C.string_of_number "offset"
+  let a_offset_transfer = user_attrib C.string_of_number "offset"
 
   let a_operator x =
     user_attrib C.string_of_big_variant "operator" x
@@ -456,71 +456,71 @@ struct
 
   let a_order = user_attrib C.string_of_number_optional_number "order"
 
-  let a_kernelmatrix = user_attrib C.string_of_numbers "kernelMatrix"
+  let a_kernelMatrix = user_attrib C.string_of_numbers "kernelMatrix"
 
   let a_divisor = user_attrib C.string_of_number "divisor"
 
   let a_bias = user_attrib C.string_of_number "bias"
 
-  let a_kernelunitlength =
+  let a_kernelUnitLength =
     user_attrib C.string_of_number_optional_number "kernelUnitLength"
 
   let a_targetX = user_attrib C.string_of_int "targetX"
 
   let a_targetY = user_attrib C.string_of_int "targetY"
 
-  let a_edgemode x =
+  let a_edgeMode x =
     user_attrib C.string_of_big_variant "targetY" x
 
-  let a_preservealpha = user_attrib C.string_of_bool "targetY"
+  let a_preserveAlpha = user_attrib C.string_of_bool "preserveAlpha"
 
-  let a_surfacescale = user_attrib C.string_of_number "surfaceScale"
+  let a_surfaceScale = user_attrib C.string_of_number "surfaceScale"
 
-  let a_diffuseconstant =
+  let a_diffuseConstant =
     user_attrib C.string_of_number "diffuseConstant"
 
   let a_scale = user_attrib C.string_of_number "scale"
 
-  let a_xchannelselector x =
+  let a_xChannelSelector x =
     user_attrib C.string_of_big_variant "xChannelSelector" x
 
-  let a_ychannelselector x =
+  let a_yChannelSelector x =
     user_attrib C.string_of_big_variant "yChannelSelector" x
 
-  let a_stddeviation =
+  let a_stdDeviation =
     user_attrib C.string_of_number_optional_number "stdDeviation"
 
-  let a_operatormorphology x =
-    user_attrib C.string_of_big_variant "operatorMorphology" x
+  let a_feMorphology_operator x =
+    user_attrib C.string_of_big_variant "operator" x
 
   let a_radius = user_attrib C.string_of_number_optional_number "radius"
 
-  let a_basefrenquency =
+  let a_baseFrenquency =
     user_attrib C.string_of_number_optional_number "baseFrequency"
 
-  let a_numoctaves = user_attrib C.string_of_int "numOctaves"
+  let a_numOctaves = user_attrib C.string_of_int "numOctaves"
 
   let a_seed = user_attrib C.string_of_number "seed"
 
-  let a_stitchtiles x =
+  let a_stitchTiles x =
     user_attrib C.string_of_big_variant "stitchTiles" x
 
-  let a_stitchtype x =
-    user_attrib C.string_of_big_variant "typeStitch" x
+  let a_feTurbulence_type x =
+    user_attrib C.string_of_big_variant "type" x
 
-  let a_xlinkshow x =
+  let a_xlink_show x =
     user_attrib C.string_of_big_variant "xlink:show" x
 
-  let a_xlinkactuate x =
+  let a_xlink_actuate x =
     user_attrib C.string_of_big_variant "xlink:actuate" x
 
   let a_target = string_attrib "xlink:target"
 
-  let a_viewtarget = string_attrib "viewTarget"
+  let a_viewTarget = string_attrib "viewTarget"
 
-  let a_attributename = string_attrib "attributeName"
+  let a_attributeName = string_attrib "attributeName"
 
-  let a_attributetype x =
+  let a_attributeType x =
     user_attrib C.string_of_big_variant "attributeType" x
 
   let a_begin = string_attrib "begin"
@@ -534,23 +534,23 @@ struct
   let a_restart x =
     user_attrib C.string_of_big_variant "restart" x
 
-  let a_repeatcount = string_attrib "repeatCount"
+  let a_repeatCount = string_attrib "repeatCount"
 
-  let a_repeatdur = string_attrib "repeatDur"
+  let a_repeatDur = string_attrib "repeatDur"
 
   let a_fill = user_attrib C.string_of_paint "fill"
 
-  let a_fill_animation x =
+  let a_animation_fill x =
     user_attrib C.string_of_big_variant "fill" x
 
-  let a_calcmode x =
+  let a_calcMode x =
     user_attrib C.string_of_big_variant "calcMode" x
 
-  let a_values_anim = Xml.comma_sep_attrib "values"
+  let a_animation_values = Xml.comma_sep_attrib "values"
 
-  let a_keytimes = Xml.comma_sep_attrib "keyTimes"
+  let a_keyTimes = Xml.comma_sep_attrib "keyTimes"
 
-  let a_keysplines = Xml.comma_sep_attrib "keySplines"
+  let a_keySplines = Xml.comma_sep_attrib "keySplines"
 
   let a_from = string_attrib "from"
 
@@ -564,11 +564,11 @@ struct
   let a_accumulate x =
     user_attrib C.string_of_big_variant "accumulate" x
 
-  let a_keypoints = user_attrib C.string_of_numbers_semicolon "keyPoints"
+  let a_keyPoints = user_attrib C.string_of_numbers_semicolon "keyPoints"
 
   let a_path = string_attrib "path"
 
-  let a_typeanimatecolor =
+  let a_animateColor_type =
     user_attrib C.string_of_big_variant "type"
 
   let a_horiz_origin_x = user_attrib C.string_of_number "horiz-origin-x"
@@ -585,12 +585,12 @@ struct
 
   let a_unicode = string_attrib "unicode"
 
-  let a_glyphname = string_attrib "glyphname"
+  let a_glyph_name = string_attrib "glyphname"
 
   let a_orientation x =
     user_attrib C.string_of_big_variant "orientation" x
 
-  let a_arabicform x =
+  let a_arabic_form x =
     user_attrib C.string_of_big_variant "arabic-form" x
 
   let a_lang = string_attrib "lang"
@@ -605,21 +605,21 @@ struct
 
   let a_k = string_attrib "k"
 
-  let a_fontfamily = string_attrib "font-family"
+  let a_font_family = string_attrib "font-family"
 
-  let a_fontstyle = string_attrib "font-style"
+  let a_font_style = string_attrib "font-style"
 
-  let a_fontvariant = string_attrib "font-variant"
+  let a_font_variant = string_attrib "font-variant"
 
-  let a_fontweight = string_attrib "font-weight"
+  let a_font_weight = string_attrib "font-weight"
 
-  let a_fontstretch = string_attrib "font-stretch"
+  let a_font_stretch = string_attrib "font-stretch"
 
-  let a_fontsize = string_attrib "font-size"
+  let a_font_size = string_attrib "font-size"
 
-  let a_unicoderange = string_attrib "unicode-range"
+  let a_unicode_range = string_attrib "unicode-range"
 
-  let a_unitsperem = string_attrib "units-per-em"
+  let a_units_per_em = string_attrib "units-per-em"
 
   let a_stemv = user_attrib C.string_of_number "stemv"
 
@@ -627,11 +627,11 @@ struct
 
   let a_slope = user_attrib C.string_of_number "slope"
 
-  let a_capheight = user_attrib C.string_of_number "cap-height"
+  let a_cap_height = user_attrib C.string_of_number "cap-height"
 
-  let a_xheight = user_attrib C.string_of_number "x-height"
+  let a_x_height = user_attrib C.string_of_number "x-height"
 
-  let a_accentheight = user_attrib C.string_of_number "accent-height"
+  let a_accent_height = user_attrib C.string_of_number "accent-height"
 
   let a_ascent = user_attrib C.string_of_number "ascent"
 
@@ -649,27 +649,27 @@ struct
 
   let a_videographic = user_attrib C.string_of_number "v-ideographic"
 
-  let a_valphabetic = user_attrib C.string_of_number "v-alphabetic"
+  let a_v_alphabetic = user_attrib C.string_of_number "v-alphabetic"
 
-  let a_vmathematical = user_attrib C.string_of_number "v-mathematical"
+  let a_v_mathematical = user_attrib C.string_of_number "v-mathematical"
 
-  let a_vhanging = user_attrib C.string_of_number "v-hanging"
+  let a_v_hanging = user_attrib C.string_of_number "v-hanging"
 
-  let a_underlineposition =
+  let a_underline_position =
     user_attrib C.string_of_number "underline-position"
 
-  let a_underlinethickness =
+  let a_underline_thickness =
     user_attrib C.string_of_number "underline-thickness"
 
-  let a_strikethroughposition =
+  let a_strikethrough_position =
     user_attrib C.string_of_number "strikethrough-position"
 
-  let a_strikethroughthickness =
+  let a_strikethrough_thickness =
     user_attrib C.string_of_number "strikethrough-thickness"
 
-  let a_overlineposition = user_attrib C.string_of_number "overline-position"
+  let a_overline_position = user_attrib C.string_of_number "overline-position"
 
-  let a_overlinethickness =
+  let a_overline_thickness =
     user_attrib C.string_of_number "overline-thickness"
 
   let a_string = string_attrib "string"
@@ -707,30 +707,30 @@ struct
   let a_onmouseout = Xml.mouse_event_handler_attrib "onmouseout"
   let a_onmousemove = Xml.mouse_event_handler_attrib "onmousemove"
 
-  let a_stopcolor = color_attrib "stop-color"
+  let a_stop_color = color_attrib "stop-color"
 
-  let a_stopopacity = user_attrib C.string_of_number "stop-opacity"
+  let a_stop_opacity = user_attrib C.string_of_number "stop-opacity"
 
   let a_stroke = user_attrib C.string_of_paint "stroke"
 
-  let a_strokewidth = user_attrib C.string_of_length "stroke-width"
+  let a_stroke_width = user_attrib C.string_of_length "stroke-width"
 
-  let a_strokelinecap x =
+  let a_stroke_linecap x =
     user_attrib C.string_of_big_variant "stroke-linecap" x
 
-  let a_strokelinejoin x =
+  let a_stroke_linejoin x =
     user_attrib C.string_of_big_variant "stroke-linejoin" x
 
-  let a_strokemiterlimit =
+  let a_stroke_miterlimit =
     user_attrib C.string_of_number "stroke-miterlimit"
 
-  let a_strokedasharray x =
+  let a_stroke_dasharray x =
     user_attrib C.string_of_strokedasharray "stroke-dasharray" x
 
-  let a_strokedashoffset =
+  let a_stroke_dashoffset =
     user_attrib C.string_of_length "stroke-dashoffset"
 
-  let a_strokeopacity =
+  let a_stroke_opacity =
     user_attrib C.string_of_number "stroke-opacity"
 
   (* xlink namespace given a nickname since some attributes mandated by

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -56,7 +56,7 @@ module type T = sig
 
   val a_version : string wrap -> [> | `Version ] attrib
 
-  val a_baseprofile : string wrap -> [> | `BaseProfile ] attrib
+  val a_baseProfile : string wrap -> [> | `BaseProfile ] attrib
 
   val a_x : coord wrap -> [> | `X ] attrib
 
@@ -66,24 +66,24 @@ module type T = sig
 
   val a_height : Unit.length wrap -> [> | `Height ] attrib
 
-  val a_preserveaspectratio : string wrap -> [> | `PreserveAspectRatio ] attrib
+  val a_preserveAspectRatio : string wrap -> [> | `PreserveAspectRatio ] attrib
 
-  val a_contentscripttype : string wrap -> [> | `ContentScriptType ] attrib
+  val a_contentScriptType : string wrap -> [> | `ContentScriptType ] attrib
 
-  val a_contentstyletype : string wrap -> [> | `ContentStyleType ] attrib
+  val a_contentStyleType : string wrap -> [> | `ContentStyleType ] attrib
 
   val a_zoomAndPan : [< | `Disable | `Magnify ] wrap -> [> | `ZoomAndSpan ] attrib
 
   val a_xlink_href : iri wrap -> [> | `Xlink_href ] attrib
 
-  val a_requiredfeatures : spacestrings wrap -> [> | `RequiredFeatures ] attrib
+  val a_requiredFeatures : spacestrings wrap -> [> | `RequiredFeatures ] attrib
 
-  val a_requiredextensions :
+  val a_requiredExtensions :
     spacestrings wrap -> [> | `RequiredExtension ] attrib
 
-  val a_systemlanguage : commastrings wrap -> [> | `SystemLanguage ] attrib
+  val a_systemLanguage : commastrings wrap -> [> | `SystemLanguage ] attrib
 
-  val a_externalressourcesrequired :
+  val a_externalRessourcesRequired :
     bool wrap -> [> | `ExternalRessourcesRequired ] attrib
 
   val a_id : string wrap -> [> | `Id ] attrib
@@ -106,11 +106,11 @@ module type T = sig
 
   val a_transform : transform wrap -> [> | `Transform ] attrib
 
-  val a_viewbox : fourfloats wrap -> [> | `ViewBox ] attrib
+  val a_viewBox : fourfloats wrap -> [> | `ViewBox ] attrib
 
   val a_d : string wrap -> [> | `D ] attrib
 
-  val a_pathlength : float wrap -> [> | `PathLength ] attrib
+  val a_pathLength : float wrap -> [> | `PathLength ] attrib
 
   (* XXX: better language support *)
   val a_rx : Unit.length wrap -> [> | `Rx ] attrib
@@ -145,10 +145,10 @@ module type T = sig
 
   val a_dy_list : lengths wrap -> [> | `Dy_list ] attrib
 
-  val a_lengthadjust :
+  val a_lengthAdjust :
     [< `Spacing | `SpacingAndGlyphs ] wrap -> [> | `LengthAdjust ] attrib
 
-  val a_textlength : Unit.length wrap -> [> | `TextLength ] attrib
+  val a_textLength : Unit.length wrap -> [> | `TextLength ] attrib
 
   val a_text_anchor : [< `Start | `Middle | `End | `Inherit ] wrap -> [> | `Text_Anchor ] attrib
 
@@ -158,32 +158,32 @@ module type T = sig
 
   val a_rotate : numbers wrap -> [> | `Rotate ] attrib
 
-  val a_startoffset : Unit.length wrap -> [> | `StartOffset ] attrib
+  val a_startOffset : Unit.length wrap -> [> | `StartOffset ] attrib
 
   val a_method : [< `Align | `Stretch ] wrap -> [> | `Method ] attrib
 
   val a_spacing : [< `Auto | `Exact ] wrap -> [> | `Spacing ] attrib
 
-  val a_glyphref : string wrap -> [> | `GlyphRef ] attrib
+  val a_glyphRef : string wrap -> [> | `GlyphRef ] attrib
 
   val a_format : string wrap -> [> | `Format ] attrib
 
-  val a_markerunits :
+  val a_markerUnits :
     [< `StrokeWidth | `UserSpaceOnUse ] wrap -> [> | `MarkerUnits ] attrib
 
-  val a_refx : coord wrap -> [> | `RefX ] attrib
+  val a_refX : coord wrap -> [> | `RefX ] attrib
 
-  val a_refy : coord wrap -> [> | `RefY ] attrib
+  val a_refY : coord wrap -> [> | `RefY ] attrib
 
-  val a_markerwidth : Unit.length wrap -> [> | `MarkerWidth ] attrib
+  val a_markerWidth : Unit.length wrap -> [> | `MarkerWidth ] attrib
 
-  val a_markerheight : Unit.length wrap -> [> | `MarkerHeight ] attrib
+  val a_markerHeight : Unit.length wrap -> [> | `MarkerHeight ] attrib
 
   val a_orient : [< `Auto | `Angle of angle ] wrap -> [> | `Orient ] attrib
 
   val a_local : string wrap -> [> | `Local ] attrib
 
-  val a_renderingindent :
+  val a_rendering_intent :
     [<
       | `Auto
       | `Perceptual
@@ -191,13 +191,13 @@ module type T = sig
       | `Saturation
       | `Absolute_colorimetric ] wrap -> [> | `Rendering_Indent ] attrib
 
-  val a_gradientunits :
+  val a_gradientUnits :
     [< `UserSpaceOnUse | `ObjectBoundingBox ] wrap ->
     [ | `GradientUnits ] attrib
 
-  val a_gradienttransform : transforms wrap -> [> | `Gradient_Transform ] attrib
+  val a_gradientTransform : transforms wrap -> [> | `Gradient_Transform ] attrib
 
-  val a_spreadmethod :
+  val a_spreadMethod :
     [< `Pad | `Reflect | `Repeat ] wrap -> [> | `SpreadMethod ] attrib
 
   val a_fx : coord wrap -> [> | `Fx ] attrib
@@ -208,32 +208,32 @@ module type T = sig
     [< `Number of number | `Percentage of percentage ] wrap ->
     [> | `Offset ] attrib
 
-  val a_patternunits :
+  val a_patternUnits :
     [< `UserSpaceOnUse | `ObjectBoundingBox ] wrap ->
     [> | `PatternUnits ] attrib
 
-  val a_patterncontentunits :
+  val a_patternContentUnits :
     [< `UserSpaceOnUse | `ObjectBoundingBox ] wrap ->
     [> | `PatternContentUnits ] attrib
 
-  val a_patterntransform : transforms wrap -> [> | `PatternTransform ] attrib
+  val a_patternTransform : transforms wrap -> [> | `PatternTransform ] attrib
 
-  val a_clippathunits :
+  val a_clipPathUnits :
     [< `UserSpaceOnUse | `ObjectBoundingBox ] wrap ->
     [> | `ClipPathUnits ] attrib
 
-  val a_maskunits :
+  val a_maskUnits :
     [< | `UserSpaceOnUse | `ObjectBoundingBox ] wrap -> [> | `MaskUnits ] attrib
 
-  val a_maskcontentunits :
+  val a_maskContentUnits :
     [< | `UserSpaceOnUse | `ObjectBoundingBox ] wrap ->
     [> | `MaskContentUnits ] attrib
 
-  val a_primitiveunits :
+  val a_primitiveUnits :
     [< | `UserSpaceOnUse | `ObjectBoundingBox ] wrap ->
     [> | `PrimitiveUnits ] attrib
 
-  val a_filterres : number_optional_number wrap -> [> | `FilterResUnits ] attrib
+  val a_filterRes : number_optional_number wrap -> [> | `FilterResUnits ] attrib
 
   val a_result : string wrap -> [> | `Result ] attrib
 
@@ -257,37 +257,37 @@ module type T = sig
       | `StrokePaint
       | `Ref of string ] wrap -> [> | `In2 ] attrib
 
-  val a_aizmuth : float wrap -> [> | `Azimuth ] attrib
+  val a_azimuth : float wrap -> [> | `Azimuth ] attrib
 
   val a_elevation : float wrap -> [> | `Elevation ] attrib
 
-  val a_pointatx : float wrap -> [> | `PointsAtX ] attrib
+  val a_pointsAtX : float wrap -> [> | `PointsAtX ] attrib
 
-  val a_pointaty : float wrap -> [> | `PointsAtY ] attrib
+  val a_pointsAtY : float wrap -> [> | `PointsAtY ] attrib
 
-  val a_pointatz : float wrap -> [> | `PointsAtZ ] attrib
+  val a_pointsAtZ : float wrap -> [> | `PointsAtZ ] attrib
 
-  val a_specularexponent : float wrap -> [> | `SpecularExponent ] attrib
+  val a_specularExponent : float wrap -> [> | `SpecularExponent ] attrib
 
-  val a_specularconstant : float wrap -> [> | `SpecularConstant ] attrib
+  val a_specularConstant : float wrap -> [> | `SpecularConstant ] attrib
 
-  val a_limitingconeangle : float wrap -> [> | `LimitingConeAngle ] attrib
+  val a_limitingConeAngle : float wrap -> [> | `LimitingConeAngle ] attrib
 
   val a_mode :
     [< | `Normal | `Multiply | `Screen | `Darken | `Lighten ] wrap ->
     [> | `Mode ] attrib
 
-  val a_typefecolor :
+  val a_feColorMatrix_type :
     [< | `Matrix | `Saturate | `HueRotate | `LuminanceToAlpha ] wrap ->
     [> | `Typefecolor ] attrib
 
   val a_values : numbers wrap -> [> | `Values ] attrib
 
-  val a_transferttype :
+  val a_type_transfer :
     [< | `Identity | `Table | `Discrete | `Linear | `Gamma ] wrap ->
-    [> | `Typetransfert ] attrib
+    [> | `Type_transfert ] attrib
 
-  val a_tablevalues : numbers wrap -> [> | `TableValues ] attrib
+  val a_tableValues : numbers wrap -> [> | `TableValues ] attrib
 
   val a_intercept : number wrap -> [> | `Intercept ] attrib
 
@@ -295,7 +295,7 @@ module type T = sig
 
   val a_exponent : number wrap -> [> | `Exponent ] attrib
 
-  val a_offsettransfer : number wrap -> [> | `Offsettransfer ] attrib
+  val a_offset_transfer : number wrap -> [> | `Offset_transfer ] attrib
 
   val a_operator :
     [< | `Over | `In | `Out | `Atop | `Xor | `Arithmetic ] wrap ->
@@ -311,69 +311,69 @@ module type T = sig
 
   val a_order : number_optional_number wrap -> [> | `Order ] attrib
 
-  val a_kernelmatrix : numbers wrap -> [> | `KernelMatrix ] attrib
+  val a_kernelMatrix : numbers wrap -> [> | `KernelMatrix ] attrib
 
   val a_divisor : number wrap -> [> | `Divisor ] attrib
 
   val a_bias : number wrap -> [> | `Bias ] attrib
 
-  val a_kernelunitlength :
+  val a_kernelUnitLength :
     number_optional_number wrap -> [> | `KernelUnitLength ] attrib
 
   val a_targetX : int wrap -> [> | `TargetX ] attrib
 
   val a_targetY : int wrap -> [> | `TargetY ] attrib
 
-  val a_edgemode :
+  val a_edgeMode :
     [< | `Duplicate | `Wrap | `None ] wrap -> [> | `TargetY ] attrib
 
-  val a_preservealpha : bool wrap -> [> | `TargetY ] attrib
+  val a_preserveAlpha : bool wrap -> [> | `TargetY ] attrib
 
-  val a_surfacescale : number wrap -> [> | `SurfaceScale ] attrib
+  val a_surfaceScale : number wrap -> [> | `SurfaceScale ] attrib
 
-  val a_diffuseconstant : number wrap -> [> | `DiffuseConstant ] attrib
+  val a_diffuseConstant : number wrap -> [> | `DiffuseConstant ] attrib
 
   val a_scale : number wrap -> [> | `Scale ] attrib
 
-  val a_xchannelselector :
+  val a_xChannelSelector :
     [< | `R | `G | `B | `A ] wrap -> [> | `XChannelSelector ] attrib
 
-  val a_ychannelselector :
+  val a_yChannelSelector :
     [< | `R | `G | `B | `A ] wrap -> [> | `YChannelSelector ] attrib
 
-  val a_stddeviation : number_optional_number wrap -> [> | `StdDeviation ] attrib
+  val a_stdDeviation : number_optional_number wrap -> [> | `StdDeviation ] attrib
 
-  val a_operatormorphology :
+  val a_feMorphology_operator :
     [< | `Erode | `Dilate ] wrap -> [> | `OperatorMorphology ] attrib
 
   val a_radius : number_optional_number wrap -> [> | `Radius ] attrib
 
-  val a_basefrenquency :
+  val a_baseFrenquency :
     number_optional_number wrap -> [> | `BaseFrequency ] attrib
 
-  val a_numoctaves : int wrap -> [> | `NumOctaves ] attrib
+  val a_numOctaves : int wrap -> [> | `NumOctaves ] attrib
 
   val a_seed : number wrap -> [> | `Seed ] attrib
 
-  val a_stitchtiles :
+  val a_stitchTiles :
     [< | `Stitch | `NoStitch ] wrap -> [> | `StitchTiles ] attrib
 
-  val a_stitchtype :
+  val a_feTurbulence_type :
     [< | `FractalNoise | `Turbulence ] wrap -> [> | `TypeStitch ] attrib
 
-  val a_xlinkshow : [< | `New | `Replace ] wrap -> [> | `Xlink_show ] attrib
+  val a_xlink_show : [< | `New | `Replace ] wrap -> [> | `Xlink_show ] attrib
 
-  val a_xlinkactuate :
+  val a_xlink_actuate :
     [< | `OnRequest | `OnLoad | `Other | `None ] wrap
     -> [> | `Xlink_actuate ] attrib
 
   val a_target : string wrap -> [> | `Xlink_target ] attrib
 
-  val a_viewtarget : string wrap -> [> | `ViewTarget ] attrib
+  val a_viewTarget : string wrap -> [> | `ViewTarget ] attrib
 
-  val a_attributename : string wrap -> [> | `AttributeName ] attrib
+  val a_attributeName : string wrap -> [> | `AttributeName ] attrib
 
-  val a_attributetype :
+  val a_attributeType :
     [< | `CSS | `XML | `Auto ] wrap -> [> | `AttributeType ] attrib
 
   val a_begin : string wrap -> [> | `Begin ] attrib
@@ -390,24 +390,24 @@ module type T = sig
   val a_restart :
     [< | `Always | `WhenNotActive | `Never ] wrap -> [> | `Restart ] attrib
 
-  val a_repeatcount : string wrap -> [> | `RepeatCount ] attrib
+  val a_repeatCount : string wrap -> [> | `RepeatCount ] attrib
 
   (* XXX *)
-  val a_repeatdur : string wrap -> [> | `RepeatDur ] attrib
+  val a_repeatDur : string wrap -> [> | `RepeatDur ] attrib
 
   (* XXX *)
   val a_fill : paint wrap -> [> | `Fill ] attrib
 
-  val a_fill_animation : [< | `Freeze | `Remove ] wrap -> [> | `Fill_Animation ] attrib
+  val a_animation_fill : [< | `Freeze | `Remove ] wrap -> [> | `Fill_Animation ] attrib
 
-  val a_calcmode :
+  val a_calcMode :
     [< | `Discrete | `Linear | `Paced | `Spline ] wrap -> [> | `CalcMode ] attrib
 
-  val a_values_anim : strings wrap -> [> | `Valuesanim ] attrib
+  val a_animation_values : strings wrap -> [> | `Valuesanim ] attrib
 
-  val a_keytimes : strings wrap -> [> | `KeyTimes ] attrib
+  val a_keyTimes : strings wrap -> [> | `KeyTimes ] attrib
 
-  val a_keysplines : strings wrap -> [> | `KeySplines ] attrib
+  val a_keySplines : strings wrap -> [> | `KeySplines ] attrib
 
   val a_from : string wrap -> [> | `From ] attrib
 
@@ -419,33 +419,33 @@ module type T = sig
 
   val a_accumulate : [< | `None | `Sum ] wrap -> [> | `Accumulate ] attrib
 
-  val a_keypoints : numbers_semicolon wrap -> [> | `KeyPoints ] attrib
+  val a_keyPoints : numbers_semicolon wrap -> [> | `KeyPoints ] attrib
 
   val a_path : string wrap -> [> | `Path ] attrib
 
-  val a_typeanimatecolor :
+  val a_animateColor_type :
     [ | `Translate | `Scale | `Rotate | `SkewX | `SkewY ] wrap ->
     [ | `Typeanimatecolor ] attrib
 
-  val a_horiz_origin_x : number wrap -> [> | `Horizoriginx ] attrib
+  val a_horiz_origin_x : number wrap -> [> | `HorizOriginX ] attrib
 
-  val a_horiz_origin_y : number wrap -> [> | `Horizoriginy ] attrib
+  val a_horiz_origin_y : number wrap -> [> | `HorizOriginY ] attrib
 
-  val a_horiz_adv_x : number wrap -> [> | `Horizadvx ] attrib
+  val a_horiz_adv_x : number wrap -> [> | `HorizAdvX ] attrib
 
-  val a_vert_origin_x : number wrap -> [> | `Vertoriginx ] attrib
+  val a_vert_origin_x : number wrap -> [> | `VertOriginX ] attrib
 
-  val a_vert_origin_y : number wrap -> [> | `Vertoriginy ] attrib
+  val a_vert_origin_y : number wrap -> [> | `VertOriginY ] attrib
 
-  val a_vert_adv_y : number wrap -> [> | `Vertadvy ] attrib
+  val a_vert_adv_y : number wrap -> [> | `VertAdvY ] attrib
 
   val a_unicode : string wrap -> [> | `Unicode ] attrib
 
-  val a_glyphname : string wrap -> [> | `glyphname ] attrib
+  val a_glyph_name : string wrap -> [> | `glyphname ] attrib
 
   val a_orientation : [< | `H | `V ] wrap -> [> | `Orientation ] attrib
 
-  val a_arabicform :
+  val a_arabic_form :
     [< | `Initial | `Medial | `Terminal | `Isolated ] wrap ->
     [> | `Arabicform ] attrib
 
@@ -461,21 +461,21 @@ module type T = sig
 
   val a_k : string wrap -> [> | `K ] attrib
 
-  val a_fontfamily : string wrap -> [> | `Font_Family ] attrib
+  val a_font_family : string wrap -> [> | `Font_Family ] attrib
 
-  val a_fontstyle : string wrap -> [> | `Font_Style ] attrib
+  val a_font_style : string wrap -> [> | `Font_Style ] attrib
 
-  val a_fontvariant : string wrap -> [> | `Font_Variant ] attrib
+  val a_font_variant : string wrap -> [> | `Font_Variant ] attrib
 
-  val a_fontweight : string wrap -> [> | `Font_Weight ] attrib
+  val a_font_weight : string wrap -> [> | `Font_Weight ] attrib
 
-  val a_fontstretch : string wrap -> [> | `Font_Stretch ] attrib
+  val a_font_stretch : string wrap -> [> | `Font_Stretch ] attrib
 
-  val a_fontsize : string wrap -> [> | `Font_Size ] attrib
+  val a_font_size : string wrap -> [> | `Font_Size ] attrib
 
-  val a_unicoderange : string wrap -> [> | `UnicodeRange ] attrib
+  val a_unicode_range : string wrap -> [> | `UnicodeRange ] attrib
 
-  val a_unitsperem : string wrap -> [> | `UnitsPerEm ] attrib
+  val a_units_per_em : string wrap -> [> | `UnitsPerEm ] attrib
 
   val a_stemv : number wrap -> [> | `Stemv ] attrib
 
@@ -483,11 +483,11 @@ module type T = sig
 
   val a_slope : number wrap -> [> | `Slope ] attrib
 
-  val a_capheight : number wrap -> [> | `CapHeight ] attrib
+  val a_cap_height : number wrap -> [> | `CapHeight ] attrib
 
-  val a_xheight : number wrap -> [> | `XHeight ] attrib
+  val a_x_height : number wrap -> [> | `XHeight ] attrib
 
-  val a_accentheight : number wrap -> [> | `AccentHeight ] attrib
+  val a_accent_height : number wrap -> [> | `AccentHeight ] attrib
 
   val a_ascent : number wrap -> [> | `Ascent ] attrib
 
@@ -505,25 +505,25 @@ module type T = sig
 
   val a_videographic : number wrap -> [> | `VIdeographic ] attrib
 
-  val a_valphabetic : number wrap -> [> | `VAlphabetic ] attrib
+  val a_v_alphabetic : number wrap -> [> | `VAlphabetic ] attrib
 
-  val a_vmathematical : number wrap -> [> | `VMathematical ] attrib
+  val a_v_mathematical : number wrap -> [> | `VMathematical ] attrib
 
-  val a_vhanging : number wrap -> [> | `VHanging ] attrib
+  val a_v_hanging : number wrap -> [> | `VHanging ] attrib
 
-  val a_underlineposition : number wrap -> [> | `UnderlinePosition ] attrib
+  val a_underline_position : number wrap -> [> | `UnderlinePosition ] attrib
 
-  val a_underlinethickness : number wrap -> [> | `UnderlineThickness ] attrib
+  val a_underline_thickness : number wrap -> [> | `UnderlineThickness ] attrib
 
-  val a_strikethroughposition :
+  val a_strikethrough_position :
     number wrap -> [> | `StrikethroughPosition ] attrib
 
-  val a_strikethroughthickness :
+  val a_strikethrough_thickness :
     number wrap -> [> | `StrikethroughThickness ] attrib
 
-  val a_overlineposition : number wrap -> [> | `OverlinePosition ] attrib
+  val a_overline_position : number wrap -> [> | `OverlinePosition ] attrib
 
-  val a_overlinethickness : number wrap -> [> | `OverlineThickness ] attrib
+  val a_overline_thickness : number wrap -> [> | `OverlineThickness ] attrib
 
   val a_string : string wrap -> [> | `String ] attrib
 
@@ -570,31 +570,32 @@ module type T = sig
   val metadata :
     ?a: ((metadata_attr attrib) list) -> Xml.elt list_wrap -> [> | metadata] elt
 
-  val foreignobject :
+  val foreignObject :
     ?a: ((foreignobject_attr attrib) list) ->
     Xml.elt list_wrap -> [> | foreignobject] elt
 
-  val a_stopcolor : color wrap -> [> | `Stop_Color ] attrib
+  val a_stop_color : color wrap -> [> | `Stop_Color ] attrib
 
-  val a_stopopacity : number wrap -> [> | `Stop_Opacity ] attrib
+  val a_stop_opacity : number wrap -> [> | `Stop_Opacity ] attrib
 
   val a_stroke : paint wrap -> [> | `Stroke ] attrib
 
-  val a_strokewidth : length wrap -> [> | `Stroke_Width ] attrib
+  val a_stroke_width : length wrap -> [> | `Stroke_Width ] attrib
 
-  val a_strokelinecap :
+  val a_stroke_linecap :
     [< `Butt | `Round | `Square ] wrap -> [> | `Stroke_Linecap ] attrib
 
-  val a_strokelinejoin :
+  val a_stroke_linejoin :
     [< `Miter | `Round | `Bever ] wrap -> [> `Stroke_Linejoin ] attrib
 
-  val a_strokemiterlimit : float wrap -> [> `Stroke_Miterlimit ] attrib
+  val a_stroke_miterlimit : float wrap -> [> `Stroke_Miterlimit ] attrib
 
-  val a_strokedasharray : Unit.length list wrap -> [> `Stroke_Dasharray ] attrib
+  val a_stroke_dasharray :
+    Unit.length list wrap -> [> `Stroke_Dasharray ] attrib
 
-  val a_strokedashoffset : Unit.length wrap -> [> `Stroke_Dashoffset ] attrib
+  val a_stroke_dashoffset : Unit.length wrap -> [> `Stroke_Dashoffset ] attrib
 
-  val a_strokeopacity : float wrap -> [> `Stroke_Opacity ] attrib
+  val a_stroke_opacity : float wrap -> [> `Stroke_Opacity ] attrib
 
   (** {1 Elements} *)
 


### PR DESCRIPTION
Per #72.

This doesn't block the ppx – I have `a_sandbox` special-cased for the time being.