### PR TITLE
Fix constraints on W.ft in the functorial interface.

### DIFF
--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -1246,6 +1246,7 @@ sig
   module type T = T
     with type 'a Xml.W.t = 'a Xml.W.t
      and type 'a Xml.W.tlist = 'a Xml.W.tlist
+     and type ('a,'b) Xml.W.ft = ('a,'b) Xml.W.ft
      and type Xml.uri = Xml.uri
      and type Xml.event_handler = Xml.event_handler
      and type Xml.mouse_event_handler = Xml.mouse_event_handler

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -952,6 +952,7 @@ module Make (Xml : Xml_sigs.T) : sig
   module type T = T
     with type 'a Xml.W.t = 'a Xml.W.t
      and type 'a Xml.W.tlist = 'a Xml.W.tlist
+     and type ('a,'b) Xml.W.ft = ('a,'b) Xml.W.ft
      and type Xml.uri = Xml.uri
      and type Xml.event_handler = Xml.event_handler
      and type Xml.mouse_event_handler = Xml.mouse_event_handler


### PR DESCRIPTION
Fix this test case:

```
module Tyxml_backend : Html5_sigs.NoWrap
= struct
  include Html5.M
  module Svg = Svg.M
end
```