### PR TITLE
Replace some option-like variants by options.

### DIFF
--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -1038,10 +1038,10 @@ module Wrapped_functions = struct
     | None -> "any"
 
   let string_of_sizes = function
-    | `Sizes l ->
+    | Some l ->
       String.concat " "
         (List.map (fun (x, y) -> Printf.sprintf "%dx%d" x y) l)
-    | `Any ->
+    | None ->
       "any"
 
   let string_of_sandbox l =

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -142,7 +142,7 @@ module type T = sig
 
   val a_seamless : [> | `Seamless] attrib
 
-  val a_sizes : [< | `Sizes of (number * number) list | `Any] wrap -> [> | `Sizes] attrib
+  val a_sizes : (number * number) list option wrap -> [> | `Sizes] attrib
 
   val a_span : number wrap -> [> | `Span] attrib
 
@@ -1222,7 +1222,7 @@ module type Wrapped_functions = sig
     ([< Html5_types.sandbox_token] list, string) ft
 
   val string_of_sizes :
-    ([< Html5_types.sizes], string) ft
+    ((Html5_types.number * Html5_types.number) list option, string) ft
 
   val string_of_srcset :
     ([< Html5_types.image_candidate] list, string) ft

--- a/lib/html5_types.mli
+++ b/lib/html5_types.mli
@@ -2352,7 +2352,3 @@ type input_type =
   | `Time
   | `Url
   | `Week ]
-
-type sizes =
-  [ `Sizes of (number * number) list
-  | `Any ]

--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -1096,8 +1096,8 @@ module Wrapped_functions = struct
     | `Percentage x -> string_of_percentage x
 
   let string_of_orient = function
-    | `Auto -> "auto"
-    | `Angle __svg -> string_of_angle __svg
+    | None -> "auto"
+    | Some __svg -> string_of_angle __svg
 
   let string_of_paint = string_of_paint
 

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -179,7 +179,7 @@ module type T = sig
 
   val a_markerHeight : Unit.length wrap -> [> | `MarkerHeight ] attrib
 
-  val a_orient : [< `Auto | `Angle of angle ] wrap -> [> | `Orient ] attrib
+  val a_orient : Unit.angle option wrap -> [> | `Orient ] attrib
 
   val a_local : string wrap -> [> | `Local ] attrib
 
@@ -930,7 +930,7 @@ module type Wrapped_functions = sig
 
   val string_of_offset : ([< Svg_types.offset], string) ft
 
-  val string_of_orient : ([< Svg_types.orient], string) ft
+  val string_of_orient : (Svg_types.Unit.angle option, string) ft
 
   val string_of_paint : ([< Svg_types.paint], string) ft
 

--- a/lib/svg_types.mli
+++ b/lib/svg_types.mli
@@ -1958,10 +1958,6 @@ type offset =
   [ `Number of float
   | `Percentage of int ]
 
-type orient =
-  [ `Auto
-  | `Angle of Unit.angle ]
-
 type big_variant =
   [ `A
   | `Absolute_colorimetric


### PR DESCRIPTION
This is consistent with how `Html5_sigs.T.a_step` is represented, and makes the ppx ever-so-slightly less tedious to program. Curious to hear about the impact on users.

**Edit**: also replacing type of `a_sizes`. I suppose we could also go the other way, keep these as they are, but change `a_step` to a variant.