### PR TITLE
Add ppx.

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,6 +1,7 @@
 S lib
 S syntax
 S tools
+S ppx
 
 B _build/*
 
@@ -9,3 +10,4 @@ FLG -w -32-34-37
 FLG -strict_sequence -safe_string
 
 PKG uutf re
+PKG compiler-libs.common ppx_tools.metaquot markup

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+OCAMLFIND_IGNORE_DUPS_IN = $(shell ocamlfind query compiler-libs)
+export OCAMLFIND_IGNORE_DUPS_IN
+
 # OASIS_START
 # DO NOT EDIT (digest: a3c674b4239234cbbe53afe090018954)
 

--- a/_oasis
+++ b/_oasis
@@ -32,6 +32,10 @@ Flag syntax
   Description: Build the camlp4 syntax extension.
   Default: true
 
+Flag ppx
+  Description: Build the ppx syntax extension.
+  Default: false
+
 Library tyxml
   FindlibName: tyxml
   Path: implem
@@ -107,6 +111,7 @@ Library tymlx_p
     Simplexmlparser
 
 Library ppx
+  Build$: flag(ppx)
   FindlibName: ppx
   FindlibParent: tyxml
   Path: ppx
@@ -117,6 +122,7 @@ Library ppx
   XMETAExtraLines: ppx = "ppx_tyxml"
 
 Executable ppx_tyxml
+  Build$: flag(ppx)
   Path: ppx
   MainIs: ppx_tyxml.ml
   BuildDepends:
@@ -126,7 +132,7 @@ Executable ppx_reflect
   Path: ppx
   MainIs: ppx_reflect.ml
   BuildDepends:
-    compiler-libs.common
+    compiler-libs.common, ppx_tools.metaquot
 
 ## Tests
 

--- a/_oasis
+++ b/_oasis
@@ -106,6 +106,28 @@ Library tymlx_p
   Modules:
     Simplexmlparser
 
+Library ppx
+  FindlibName: ppx
+  FindlibParent: tyxml
+  Path: ppx
+  InternalModules: Ppx_tyxml
+  XMETADescription:
+    HTML5 and SVG syntax extension (ppx)
+  XMETARequires: tyxml
+  XMETAExtraLines: ppx = "ppx_tyxml"
+
+Executable ppx_tyxml
+  Path: ppx
+  MainIs: ppx_tyxml.ml
+  BuildDepends:
+    str, ppx_tools.metaquot, markup, tyxml.tools
+
+Executable ppx_reflect
+  Path: ppx
+  MainIs: ppx_reflect.ml
+  BuildDepends:
+    compiler-libs.common
+
 ## Tests
 
 Executable emit_big
@@ -173,4 +195,4 @@ Document "tyxml-api"
   BuildTools: ocamldoc
   XOCamlbuildPath: ./
   XOCamlbuildLibraries:
-    tyxml, tyxml.functor, tyxml.parser, tyxml.syntax
+    tyxml, tyxml.functor, tyxml.parser, tyxml.syntax, tyxml.ppx

--- a/_oasis
+++ b/_oasis
@@ -133,6 +133,7 @@ Executable ppx_reflect
   MainIs: ppx_reflect.ml
   BuildDepends:
     compiler-libs.common, ppx_tools.metaquot
+  CompiledObject: best
 
 ## Tests
 

--- a/_oasis
+++ b/_oasis
@@ -130,6 +130,7 @@ Executable ppx_tyxml
   CompiledObject: best
 
 Executable ppx_reflect
+  Build$: flag(ppx)
   Path: ppx
   MainIs: ppx_reflect.ml
   BuildDepends:

--- a/_oasis
+++ b/_oasis
@@ -127,6 +127,7 @@ Executable ppx_tyxml
   MainIs: ppx_tyxml.ml
   BuildDepends:
     re.str, ppx_tools.metaquot, markup, tyxml.tools
+  CompiledObject: best
 
 Executable ppx_reflect
   Path: ppx

--- a/_oasis
+++ b/_oasis
@@ -126,7 +126,7 @@ Executable ppx_tyxml
   Path: ppx
   MainIs: ppx_tyxml.ml
   BuildDepends:
-    str, ppx_tools.metaquot, markup, tyxml.tools
+    re.str, ppx_tools.metaquot, markup, tyxml.tools
 
 Executable ppx_reflect
   Path: ppx

--- a/_tags
+++ b/_tags
@@ -11,3 +11,6 @@ not <syntax/*>: warn_error(+1..49), warn_error(-45-3)
 not <syntax/*>: strict_sequence, safe_string, short_paths
 
 true: keep_locs
+
+# Tests use the tyxml ppx
+<test/*.ml>: ppx_tyxml

--- a/lib/html5_f.ml
+++ b/lib/html5_f.ml
@@ -85,9 +85,6 @@ struct
   (* space-separated *)
   let length_attrib = user_attrib C.string_of_multilength
 
-  let multilengths_attrib name x =
-    user_attrib C.string_of_multilengths name x
-
   let linktypes_attrib name x =
     user_attrib C.string_of_linktypes name x
 
@@ -460,10 +457,6 @@ struct
   let a_data = uri_attrib "data"
 
   let a_codetype = string_attrib "codetype"
-
-  let a_fs_rows mls = multilengths_attrib "rows" mls
-
-  let a_fs_cols mls = multilengths_attrib "cols" mls
 
   let a_frameborder x =
     user_attrib C.string_of_big_variant "frameborder" x
@@ -1041,9 +1034,6 @@ struct
 
   let string_of_numbers l =
     String.concat "," (List.map string_of_number l)
-
-  let string_of_multilengths l =
-    String.concat ", " (List.map string_of_multilength l)
 
   let string_of_mediadesc l =
     String.concat ", " (List.map string_of_mediadesc_token l)

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -309,10 +309,12 @@ module type T = sig
   val a_max : float_number wrap -> [> | `Max] attrib
 
   val a_input_max : float_number wrap -> [> | `Input_Max] attrib
+    [@@reflect.attribute "max" ["input"]]
 
   val a_min : float_number wrap -> [> | `Min] attrib
 
   val a_input_min : float_number wrap -> [> | `Input_Min] attrib
+    [@@reflect.attribute "min" ["input"]]
 
   val a_novalidate : [> | `Novalidate] attrib
 
@@ -360,6 +362,7 @@ module type T = sig
   val a_srcset : image_candidate list wrap -> [> | `Srcset] attrib
 
   val a_img_sizes : text list wrap -> [> | `Img_sizes] attrib
+    [@@reflect.attribute "sizes" ["img"]]
 
   val a_start : number wrap -> [> | `Start] attrib
 
@@ -456,6 +459,7 @@ module type T = sig
   val a_for : idref wrap -> [> | `For] attrib
 
   val a_for_list : idrefs wrap -> [> | `For_List] attrib
+    [@@reflect.attribute "for" ["output"]]
 
   val a_maxlength : number wrap -> [> | `Maxlength] attrib
 
@@ -506,29 +510,36 @@ module type T = sig
     | `Date
     | `Color
     | `Button] wrap -> [> | `Input_Type] attrib
+      [@@reflect.attribute "type" ["input"]]
 
   val a_text_value : text wrap -> [> | `Text_Value] attrib
+    [@@reflect.attribute "value" ["param"; "button"; "option"]]
   (** This attribute specifies the initial value of the
       control. If this attribute is not set, the initial value is
       set to the contents of the [option] element. *)
 
   val a_int_value : number wrap -> [> | `Int_Value] attrib
+    [@@reflect.attribute "value" ["li"]]
 
   (*VVV NO *)
   val a_value : cdata wrap -> [> | `Value] attrib
 
   val a_float_value : float_number wrap -> [> | `Float_Value] attrib
+    [@@reflect.attribute "value" ["progress"; "meter"]]
 
   val a_disabled : [> | `Disabled] attrib
 
   val a_readonly : [> | `ReadOnly] attrib
   val a_button_type :
     [< | `Button | `Submit | `Reset] wrap -> [> | `Button_Type] attrib
+      [@@reflect.attribute "type" ["button"]]
 
   val a_command_type :
     [< | `Command | `Checkbox | `Radio] wrap -> [> | `Command_Type] attrib
+      [@@reflect.attribute "type" ["command"]]
 
   val a_menu_type : [< | `Context | `Toolbar] wrap -> [> | `Menu_Type] attrib
+    [@@reflect.attribute "type" ["menu"]]
 
   val a_label : text wrap -> [> | `Label] attrib
 
@@ -614,10 +625,12 @@ module type T = sig
   val html :
     ?a: ((html_attrib attrib) list) ->
     [< | `Head] elt wrap -> [< | `Body] elt wrap -> [> | `Html] elt
+      [@@reflect.element "html"]
 
   val head :
     ?a: ((head_attrib attrib) list) ->
     [< | `Title] elt wrap -> (head_content_fun elt) list_wrap -> [> | head] elt
+      [@@reflect.element "head"]
 
   val base : ([< | base_attrib], [> | base]) nullary
 
@@ -698,6 +711,7 @@ module type T = sig
   val figure :
     ?figcaption: ([`Top of [< `Figcaption ] elt wrap | `Bottom of [< `Figcaption ] elt wrap ]) ->
     ([< | figure_attrib], [< | figure_content_fun], [> | figure]) star
+      [@@reflect.element "figure"]
 
   val hr : ([< | hr_attrib], [> | hr]) nullary
 
@@ -783,6 +797,7 @@ module type T = sig
       | `Name
       | `Usemap
     ], 'a, [> | `Object of 'a ]) star
+      [@@reflect.element "object_" "object"]
 
   val param : ([< | param_attrib], [> | param]) nullary
 
@@ -793,11 +808,13 @@ module type T = sig
     ?src:Xml.uri wrap ->
     ?srcs:(([< | source] elt) list_wrap) ->
     ([< | audio_attrib], 'a, [> 'a audio ]) star
+      [@@reflect.element "audio_video"]
 
   val video :
     ?src:Xml.uri wrap ->
     ?srcs: (([< | source] elt) list_wrap) ->
     ([< | video_attrib], 'a, [> 'a video]) star
+      [@@reflect.element "audio_video"]
 
   val canvas : ([< | canvas_attrib], 'a, [> | 'a canvas]) star
 
@@ -830,6 +847,7 @@ module type T = sig
     ?thead: [< | thead] elt wrap ->
     ?tfoot: [< | tfoot] elt wrap ->
     ([< | table_attrib], [< | table_content_fun], [> | table]) star
+      [@@reflect.element "table"]
 
   val tablex :
     ?caption: [< | caption] elt wrap ->
@@ -837,6 +855,7 @@ module type T = sig
     ?thead: [< | thead] elt wrap ->
     ?tfoot: [< | tfoot] elt wrap ->
     ([< | tablex_attrib], [< | tablex_content_fun], [> | tablex]) star
+      [@@reflect.element "table" "table"]
 
   val colgroup :
     ([< | colgroup_attrib], [< | colgroup_content_fun], [> | colgroup]) star
@@ -866,6 +885,7 @@ module type T = sig
     ?legend: [ | `Legend ] elt wrap ->
     ([< | common | `Disabled | `Form | `Name], [< | flow5],
      [> | `Fieldset]) star
+      [@@reflect.element "fieldset"]
 
   val legend :
     ([< | legend_attrib], [< | legend_content_fun], [> | legend]) star
@@ -891,6 +911,7 @@ module type T = sig
         | `Options of ([< | `Option] elt) list_wrap
         | `Phras of ([< | phrasing] elt) list_wrap
       ]) -> ([< | common], [> | `Datalist]) nullary
+        [@@reflect.element "datalist"]
 
   val optgroup :
     label: text wrap  ->
@@ -929,6 +950,7 @@ module type T = sig
   val details :
     [< | `Summary] elt wrap ->
     ([< | common | `Open], [< | flow5], [> | `Details]) star
+      [@@reflect.element "details"]
 
   val summary :
     ([< | summary_attrib], [< | summary_content_fun], [> | summary]) star
@@ -950,6 +972,7 @@ module type T = sig
         | `Lis of ([< | `Li of [< | common]] elt) list_wrap
         | `Flows of ([< | flow5] elt) list_wrap
       ]) -> ([< | common | `Label | `Menu_Type], [> | `Menu]) nullary
+        [@@reflect.element "menu"]
 
   (** {3 Scripting} *)
 

--- a/lib/html5_sigs.mli
+++ b/lib/html5_sigs.mli
@@ -592,10 +592,6 @@ module type T = sig
 
   val a_codetype : contenttype wrap -> [> | `Codetype] attrib
 
-  val a_fs_rows : multilengths wrap -> [> | `FS_Rows] attrib
-
-  val a_fs_cols : multilengths wrap -> [> | `FS_Cols] attrib
-
   val a_frameborder : [< | `Zero | `One] wrap -> [> | `Frameborder] attrib
 
   val a_marginheight : pixels wrap -> [> | `Marginheight] attrib
@@ -1128,9 +1124,6 @@ module type Wrapped_functions = sig
 
   val string_of_multilength :
     ([< Html5_types.multilength], string) Xml.W.ft
-
-  val string_of_multilengths :
-    ([< Html5_types.multilength] list, string) Xml.W.ft
 
   val string_of_numbers : (Html5_types.numbers, string) Xml.W.ft
 

--- a/lib/html5_types.mli
+++ b/lib/html5_types.mli
@@ -122,7 +122,7 @@ type linktype =
     | `Sidebar
     | `Tag
     | `Up
-    | `Other of string ]
+    | `Other of string ] [@@reflect.total_variant]
 
 type linktypes = linktype list
 (** Authors may use the following recognized link types, listed here with
@@ -194,7 +194,7 @@ type mediadesc_token =
   | `Speech
   | `TTY
   | `TV
-  | `Raw_mediadesc of string ]
+  | `Raw_mediadesc of string ] [@@reflect.total_variant]
 
 type mediadesc = mediadesc_token list
 

--- a/lib/html5_types.mli
+++ b/lib/html5_types.mli
@@ -237,10 +237,6 @@ type multilength = [ | length | `Relative of int ]
         ["2*"], and ["3*"], the ["1*"] will be allotted 10 pixels, the ["2*"] will be
         allotted 20 pixels, and the ["3*"] will be allotted 30 pixels. *)
 
-(* comma-separated *)
-type multilengths = multilength list
-(** A comma separated list of items of type MultiLength. *)
-
 type number = int
 
 (* space-separated *)

--- a/lib/svg_types.mli
+++ b/lib/svg_types.mli
@@ -1952,7 +1952,7 @@ type in_value =
   | `BackgroundAlpha
   | `FillPaint
   | `StrokePaint
-  | `Ref of string ]
+  | `Ref of string ] [@@reflect.total_variant]
 
 type offset =
   [ `Number of float

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -42,8 +42,12 @@ let reflect_ppx () =
 
   rule "ppx_reflect: mli -> _reflected.ml" ~prod ~deps:[dep; ppx_reflect]
     begin fun env _ ->
-      Cmd (S [A ppx_reflect ; A (env dep); A (env prod)])
+      Cmd (S [A ppx_reflect ; P (env dep); P (env prod)])
     end
+
+let tyxml_ppx () =
+  let ppx_tyxml = "ppx/ppx_tyxml."^native_suffix in
+  flag_and_dep [ "ocaml" ; "compile" ; "ppx_tyxml" ] (S [A "-ppx"; P ppx_tyxml])
 
 let () =
   dispatch
@@ -64,7 +68,8 @@ let () =
          if String.sub Sys.ocaml_version 0 4 = "4.00" then
            flag ["ocaml"; "bin_annot"; "compile"] (A "-bin-annot");
 
-        reflect_ppx ()
+         reflect_ppx () ;
+         tyxml_ppx () ;
 
        | _ ->
          ())

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -25,6 +25,21 @@
 
 open Ocamlbuild_plugin
 
+let reflect_ppx () =
+  let ppx_reflect = "ppx/ppx_reflect.byte" in
+
+  let prod = "ppx/%_reflected.ml" in
+  let dep = "lib/%.mli" in
+
+  rule "ppx_reflect: mli -> _reflected.ml" ~prod ~deps:[dep; ppx_reflect]
+    begin fun env _ ->
+      Cmd (S
+        [A "ocamlc";
+         A "-I"; A "lib";
+         A "-ppx"; A (Printf.sprintf "%s %s" ppx_reflect (env prod));
+         A "-c"; A (env dep)])
+    end
+
 let () =
   dispatch
     (fun hook ->
@@ -43,6 +58,8 @@ let () =
          (* the "bin_annot" tag was only introduced in ocamlbuild-4.01 *)
          if String.sub Sys.ocaml_version 0 4 = "4.00" then
            flag ["ocaml"; "bin_annot"; "compile"] (A "-bin-annot");
+
+        reflect_ppx ()
 
        | _ ->
          ())

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -25,19 +25,24 @@
 
 open Ocamlbuild_plugin
 
+(* Determine extension of CompiledObject: best *)
+let native_suffix =
+  let env =
+    BaseEnvLight.load ~allow_empty:true
+      ~filename:MyOCamlbuildBase.env_filename ()
+  in
+  if BaseEnvLight.var_get "is_native" env = "true"
+  then "native" else "byte"
+
 let reflect_ppx () =
-  let ppx_reflect = "ppx/ppx_reflect.byte" in
+  let ppx_reflect = "ppx/ppx_reflect."^native_suffix in
 
   let prod = "ppx/%_reflected.ml" in
   let dep = "lib/%.mli" in
 
   rule "ppx_reflect: mli -> _reflected.ml" ~prod ~deps:[dep; ppx_reflect]
     begin fun env _ ->
-      Cmd (S
-        [A "ocamlc";
-         A "-I"; A "lib";
-         A "-ppx"; A (Printf.sprintf "%s %s" ppx_reflect (env prod));
-         A "-c"; A (env dep)])
+      Cmd (S [A ppx_reflect ; A (env dep); A (env prod)])
     end
 
 let () =

--- a/opam
+++ b/opam
@@ -11,12 +11,14 @@ dev-repo: "https://github.com/ocsigen/tyxml.git"
 build: [
   ["ocaml" "setup.ml" "-configure"
       "--%{camlp4:enable}%-syntax"
+      "--%{ppx_tools:enable}%-ppx"
       "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
 build-test: [
   ["ocaml" "setup.ml" "-configure"
       "--%{camlp4:enable}%-syntax"
+      "--%{ppx_tools:enable}%-ppx"
       "--enable-tests"
       "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
@@ -31,6 +33,7 @@ depends: [
   "uutf"
   "base-bytes"
   "re"
+  ( "base-no-ppx" | "ppx_tools" )
   "alcotest" {test}
   ## OASIS is not required in released version
   "oasis" {build & >= "0.4.4"}

--- a/opam
+++ b/opam
@@ -33,6 +33,7 @@ depends: [
   "uutf"
   "base-bytes"
   "re"
+  "markup"
   ( "base-no-ppx" | "ppx_tools" )
   "alcotest" {test}
   ## OASIS is not required in released version

--- a/ppx/ppx_attribute_value.ml
+++ b/ppx/ppx_attribute_value.ml
@@ -1,0 +1,597 @@
+(* TyXML
+ * http://www.ocsigen.org/tyxml
+ * Copyright (C) 2016 Anton Bachin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
+*)
+
+open Asttypes
+
+(* Not opening all of Ast_helper in order to avoid shadowing stdlib's Str with
+   Ast_helper.Str. *)
+module Exp = Ast_helper.Exp
+
+
+
+type parser =
+  ?separated_by:string -> ?default:string -> Location.t -> string -> string ->
+    Parsetree.expression option
+
+
+
+(* Options. *)
+
+let option none (parser : parser) ?separated_by ?default:_ loc name s =
+  if s = none then Some [%expr None] [@metaloc loc]
+  else
+    match parser ~default:none loc name s with
+    | None -> None
+    | Some e -> Some [%expr Some [%e e]] [@metaloc loc]
+
+
+
+(* Lists. *)
+
+let _filter_map f l =
+  l
+  |> List.fold_left (fun acc v ->
+    match f v with
+    | None -> acc
+    | Some v' -> v'::acc)
+    []
+  |> List.rev
+
+(* Splits the given string on the given delimiter (a regular expression), then
+   applies [element_parser] to each resulting component. Each such application
+   resulting in [Some expr] is included in the resulting expression list. *)
+let _exp_list delimiter separated_by (element_parser : parser) loc name s =
+  Str.split delimiter s
+  |> _filter_map (element_parser ~separated_by loc name)
+
+(* Behaves as _expr_list, but wraps the resulting expression list as a list
+   expression. *)
+let _list
+    delimiter separated_by element_parser ?separated_by:_ ?default loc name s =
+
+  _exp_list delimiter separated_by element_parser loc name s
+  |> Ppx_common.list_exp loc
+  |> fun e -> Some e
+
+let spaces = _list (Str.regexp " +") "space"
+let commas = _list (Str.regexp " *, *") "comma"
+let semicolons = _list (Str.regexp " *; *") "semicolon"
+
+let _spaces_or_commas_regexp = Str.regexp "\\( *, *\\)\\| +"
+let _spaces_or_commas = _exp_list _spaces_or_commas_regexp "space- or comma"
+let spaces_or_commas = _list _spaces_or_commas_regexp "space- or comma"
+
+
+
+(* Wrapping. *)
+
+let wrap (parser : parser) implementation ?separated_by ?default loc name s =
+  match parser loc name s with
+  | None -> Ppx_common.error loc "wrap applied to presence; nothing to wrap"
+  | Some e -> Some (Ppx_common.wrap_exp implementation loc e)
+
+let nowrap (parser : parser) _ ?separated_by ?default loc name s =
+  parser loc name s
+
+
+
+(* Error reporting for values in lists and options. *)
+
+let _must_be_a
+    singular_description plural_description separated_by default loc name =
+
+  let description =
+    match separated_by with
+    | Some separated_by ->
+      Printf.sprintf "a %s-separated list of %s" separated_by plural_description
+    | None ->
+      match default with
+      | Some default -> Printf.sprintf "%s or %s" singular_description default
+      | None -> singular_description
+  in
+
+  Ppx_common.error loc "Value of %s must be %s" name description
+
+
+
+(* General helpers. *)
+
+(* Checks that the given string matches the given regular expression exactly,
+   i.e. the match begins at position 0 and ends at the end of the string. *)
+let _does_match regexp s =
+  Str.string_match regexp s 0 && Str.match_end () = String.length s
+
+(* Checks that the group with the given index was matched in the given
+   string. *)
+let _group_matched index s =
+  try Str.matched_group index s |> ignore; true
+  with Not_found -> false
+
+let _int_exp loc s =
+  try Some (Ppx_common.int_exp loc (int_of_string s))
+  with Failure "int_of_string" -> None
+
+let _float_exp loc s =
+  try
+    float_of_string s |> ignore;
+    Some (Ppx_common.float_exp loc s)
+  with Failure "float_of_string" ->
+    None
+
+
+
+(* Numeric. *)
+
+let char ?separated_by ?default loc name s =
+  let open Markup in
+  let open Markup.Encoding in
+
+  let report _ error =
+    Ppx_common.error loc "%s in attribute %s"
+      (Markup.Error.to_string error |> String.capitalize) name
+  in
+  let decoded = string s |> decode ~report utf_8 in
+
+  let c =
+    match next decoded with
+    | None -> Ppx_common.error loc "No character in attribute %s" name
+    | Some i ->
+      try Char.chr i
+      with Invalid_argument "Char.chr" ->
+        Ppx_common.error loc "Character out of range in attribute %s" name
+  in
+
+  begin match next decoded with
+  | None -> ()
+  | Some _ -> Ppx_common.error loc "Multiple characters in attribute %s" name
+  end;
+
+  Some (Exp.constant ~loc (Const_char c))
+
+let bool ?separated_by ?default loc name s =
+  begin
+    try bool_of_string s |> ignore
+    with Invalid_argument "bool_of_string" ->
+      Ppx_common.error loc "Value of %s must be \"true\" or \"false\"" name
+  end;
+
+  Some (Exp.construct ~loc (Location.mkloc (Longident.parse s) loc) None)
+
+let int ?separated_by ?default loc name s =
+  match _int_exp loc s with
+  | Some _ as e -> e
+  | None ->
+    _must_be_a "a whole number" "whole numbers" separated_by default loc name
+
+let float ?separated_by ?default loc name s =
+  match _float_exp loc s with
+  | Some _ as e -> e
+  | None ->
+    _must_be_a
+      "a number (decimal fraction)" "numbers (decimal fractions)"
+      separated_by default loc name
+
+let points ?separated_by ?default loc name s =
+  let expressions = _spaces_or_commas float loc name s in
+
+  let rec pair acc = function
+    | [] -> List.rev acc |> Ppx_common.list_exp loc
+    | [_] -> Ppx_common.error loc "Unpaired coordinate in %s" name
+    | ex::ey::rest -> pair (([%expr [%e ex], [%e ey]] [@metaloc loc])::acc) rest
+  in
+
+  Some (pair [] expressions)
+
+let number_pair ?separated_by ?default loc name s =
+  let e =
+    begin match _spaces_or_commas float loc name s with
+    | [orderx] -> [%expr [%e orderx], None]
+    | [orderx; ordery] -> [%expr [%e orderx], Some [%e orderx]]
+    | _ -> Ppx_common.error loc "%s requires one or two numbers" name
+    end [@metaloc loc]
+  in
+
+  Some e
+
+let fourfloats ?separated_by ?default loc name s =
+  match _spaces_or_commas float loc name s with
+  | [min_x; min_y; width; height] ->
+    Some [%expr ([%e min_x], [%e min_y], [%e width], [%e height])]
+      [@metaloc loc]
+  | _ -> Ppx_common.error loc "Value of %s must be four numbers" name
+
+(* These are always in a list; hence the error message. *)
+let icon_size =
+  let regexp = Str.regexp "\\([0-9]+\\)[xX]\\([0-9]+\\)" in
+
+  fun ?separated_by ?default loc name s ->
+    if not @@ _does_match regexp s then
+      Ppx_common.error loc "Value of %s must be a %s, or %s"
+        name "space-separated list of icon sizes, such as 16x16" "any";
+
+    let width, height =
+      try
+        int_of_string (Str.matched_group 1 s),
+        int_of_string (Str.matched_group 2 s)
+      with Invalid_argument "int_of_string" ->
+        Ppx_common.error loc "Icon dimension out of range in %s" name
+    in
+
+    Some
+      [%expr
+        [%e Ppx_common.int_exp loc width],
+        [%e Ppx_common.int_exp loc height]] [@metaloc loc]
+
+
+
+(* Dimensional. *)
+
+let length =
+  let regexp = Str.regexp "\\([0-9]+\\)\\([^0-9]+\\)" in
+
+  fun ?separated_by ?default loc name s ->
+    if not @@ _does_match regexp s then
+      Ppx_common.error
+        loc "Value of %s must be a length, such as 100px or 50%%" name;
+
+    let n =
+      match _int_exp loc (Str.matched_group 1 s) with
+      | Some n -> n
+      | None ->
+        Ppx_common.error loc "Value of %s out of range" name
+    in
+
+    let e =
+      begin match Str.matched_group 2 s with
+      | "%" -> [%expr `Percent [%e n]]
+      | "px" -> [%expr `Pixels [%e n]]
+      | unit -> Ppx_common.error loc "Unknown unit %s in %s" unit name
+      end [@metaloc loc]
+    in
+
+    Some e
+
+(* This is only called by the commas combinator; hence the error message. *)
+let multilength =
+  let regexp = Str.regexp "\\([0-9]+\\)\\(%\\|px\\)\\|\\([0-9]+\\)?\\*" in
+
+  fun ?separated_by ?default loc name s ->
+    if not @@ _does_match regexp s then
+      Ppx_common.error loc "Value of %s must be a %s"
+        name "list of relative lengths, such as 100px, 50%, or *";
+
+    begin
+      if _group_matched 1 s then
+        let n =
+          match _int_exp loc (Str.matched_group 1 s) with
+          | Some n -> n
+          | None ->
+            Ppx_common.error loc "Value in %s out of range" name
+        in
+
+        match Str.matched_group 2 s with
+        | "%" -> Some [%expr `Percent [%e n]]
+        | "px" -> Some [%expr `Pixels [%e n]]
+        | _ -> Ppx_common.error loc "Internal error: Ppx_attribute.multilength"
+
+      else
+        let n =
+          match _int_exp loc (Str.matched_group 3 s) with
+          | exception Not_found -> [%expr 1]
+          | Some n -> n
+          | None ->
+            Ppx_common.error loc "Relative length in %s out of range" name
+        in
+
+        Some [%expr `Relative [%e n]]
+    end [@metaloc loc]
+
+let _svg_quantity =
+  let integer = "[+-]?[0-9]+" in
+  let integer_scientific = Printf.sprintf "%s\\([Ee]%s\\)?" integer integer in
+  let fraction = Printf.sprintf "[+-]?[0-9]*\\.[0-9]+\\([Ee]%s\\)?" integer in
+  let number = Printf.sprintf "%s\\|%s" integer_scientific fraction in
+  let quantity = Printf.sprintf "\\(%s\\)\\([^0-9]*\\)$" number in
+  let regexp = Str.regexp quantity in
+
+  fun kind_singular kind_plural parse_unit ?separated_by ?default loc name s ->
+    if not @@ _does_match regexp s then
+      _must_be_a kind_singular kind_plural separated_by default loc name;
+
+    let n =
+      match _float_exp loc (Str.matched_group 1 s) with
+      | Some n -> n
+      | None -> Ppx_common.error loc "Number out of range in %s" name
+    in
+
+    let unit_string = Str.matched_group 4 s in
+    let unit =
+      (if unit_string = "" then [%expr None]
+      else [%expr Some [%e parse_unit loc name unit_string]]) [@metaloc loc]
+    in
+
+    [%expr [%e n], [%e unit]] [@metaloc loc]
+
+let svg_length =
+  let parse_unit loc name unit =
+    begin match unit with
+    | "cm" -> [%expr `Cm]
+    | "em" -> [%expr `Em]
+    | "ex" -> [%expr `Ex]
+    | "in" -> [%expr `In]
+    | "mm" -> [%expr `Mm]
+    | "pc" -> [%expr `Pc]
+    | "pt" -> [%expr `Pt]
+    | "px" -> [%expr `Px]
+    | "%" -> [%expr `Percent]
+    | s -> Ppx_common.error loc "Invalid length unit %s in %s" s name
+    end [@metaloc loc]
+  in
+
+  fun ?separated_by ?default loc name s ->
+    Some
+      (_svg_quantity "an SVG length" "SVG lengths" parse_unit
+        ?separated_by ?default loc name s)
+
+let _angle =
+  let parse_unit loc name unit =
+    begin match unit with
+    | "deg" -> [%expr `Deg]
+    | "rad" -> [%expr `Rad]
+    | "grad" -> [%expr `Grad]
+    | s -> Ppx_common.error loc "Invalid angle unit %s in %s" s name
+    end [@metaloc loc]
+  in
+
+  _svg_quantity "an SVG angle" "SVG angles" parse_unit
+
+let angle ?separated_by ?default loc name s =
+  Some (_angle ?separated_by ?default loc name s)
+
+let offset =
+  let bad_form name loc =
+    Ppx_common.error loc "Value of %s must be a number or percentage" name in
+
+  let regexp = Str.regexp "\\([-+0-9eE.]+\\)$\\|\\([0-9]+\\)%" in
+
+  fun ?separated_by ?default loc name s ->
+    if not @@ _does_match regexp s then bad_form name loc;
+
+    begin
+      if _group_matched 1 s then
+        let n =
+          match _float_exp loc s with
+          | Some n -> n
+          | None -> bad_form name loc
+        in
+
+        Some [%expr `Number [%e n]]
+
+      else
+        let n =
+          match _int_exp loc (Str.matched_group 2 s) with
+          | Some n -> n
+          | None ->
+            Ppx_common.error loc "Percentage out of range in %s" name
+        in
+
+        Some [%expr `Percentage [%e n]]
+    end [@metaloc loc]
+
+let transform =
+  let regexp = Str.regexp "\\([^(]+\\)(\\([^)]*\\))" in
+
+  fun ?separated_by ?default loc name s ->
+    if not @@ _does_match regexp s then
+      Ppx_common.error loc "Value of %s must be an SVG transform" name;
+
+    let kind = Str.matched_group 1 s in
+    let values = Str.matched_group 2 s in
+
+    let e =
+      begin match kind with
+      | "matrix" ->
+        begin match _spaces_or_commas float loc "matrix" values with
+        | [a; b; c; d; e; f] ->
+          [%expr Svg_types.Matrix
+            ([%e a], [%e b], [%e c], [%e d], [%e e], [%e f])]
+        | _ ->
+          Ppx_common.error loc "%s: matrix requires six numbers" name
+        end
+
+      | "translate" ->
+        begin match _spaces_or_commas float loc "translate" values with
+        | [tx; ty] -> [%expr Svg_types.Translate ([%e tx], Some [%e ty])]
+        | [tx] -> [%expr Svg_types.Translate ([%e tx], None)]
+        | _ ->
+          Ppx_common.error loc "%s: translate requires one or two numbers" name
+        end
+
+      | "scale" ->
+        begin match _spaces_or_commas float loc "scale" values with
+        | [sx; sy] -> [%expr Svg_types.Scale ([%e sx], Some [%e sy])]
+        | [sx] -> [%expr Svg_types.Scale ([%e sx], None)]
+        | _ ->
+          Ppx_common.error loc "%s: scale requires one or two numbers" name
+        end
+
+      | "rotate" ->
+        begin match Str.bounded_split _spaces_or_commas_regexp values 2 with
+        | [angle] ->
+          [%expr Svg_types.Rotate ([%e _angle loc "rotate" angle], None)]
+        | [angle; axis] ->
+          begin match _spaces_or_commas float loc "rotate axis" axis with
+          | [cx; cy] ->
+            [%expr Svg_types.Rotate
+              ([%e _angle loc "rotate" angle], Some ([%e cx], [%e cy]))]
+          | _ ->
+            Ppx_common.error loc "%s: rotate center requires two numbers" name
+          end
+        | _ ->
+          Ppx_common.error loc
+            "%s: rotate requires an angle and an optional center" name
+        end
+
+      | "skewX" -> [%expr Svg_types.SkewX [%e _angle loc "skewX" values]]
+
+      | "skewY" -> [%expr Svg_types.SkewY [%e _angle loc "skewY" values]]
+
+      | s -> Ppx_common.error loc "%s: %s is not a valid transform type" name s
+      end [@metaloc loc]
+    in
+
+    Some e
+
+
+
+(* String-like. *)
+
+let string ?separated_by ?default loc _ s =
+  Some (Exp.constant ~loc (Const_string (s, None)))
+
+let _variand s =
+  let without_backtick s =
+    let length = String.length s in
+    String.sub s 1 (length - 1)
+  in
+
+  s |> Tyxml_name.polyvar |> without_backtick
+
+let variant ?separated_by ?default loc _ s =
+  Some (Exp.variant ~loc (_variand s) None)
+
+let total_variant (unary, nullary) ?separated_by ?default loc name s =
+  let variand = _variand s in
+  if List.mem variand nullary then Some (Exp.variant ~loc variand None)
+  else Some (Exp.variant ~loc unary (Some (Ppx_common.string_exp loc s)))
+
+
+
+(* Miscellaneous. *)
+
+let presence ?separated_by ?default _ _ _ = None
+
+let _paint_without_icc loc name s =
+  begin match s with
+  | "none" ->
+    [%expr `None]
+
+  | "currentColor" ->
+    [%expr `CurrentColor]
+
+  | _ ->
+    let icc_color_start =
+      try Some (Str.search_forward (Str.regexp "icc-color(\\([^)]*\\))") s 0)
+      with Not_found -> None
+    in
+
+    match icc_color_start with
+    | None -> [%expr `Color ([%e Ppx_common.string_exp loc s], None)]
+    | Some i ->
+      let icc_color = Str.matched_group 1 s in
+      let color = String.sub s 0 i in
+      [%expr `Color
+        ([%e Ppx_common.string_exp loc color],
+         Some [%e Ppx_common.string_exp loc icc_color])]
+  end [@metaloc loc]
+
+let paint ?separated_by ?default loc name s =
+  if not @@ Str.string_match (Str.regexp "url(\\([^)]+\\))") s 0 then
+    Some (_paint_without_icc loc name s)
+  else
+    let iri = Str.matched_group 1 s |> Ppx_common.string_exp loc in
+    let remainder_start = Str.group_end 0 in
+    let remainder_length = String.length s - remainder_start in
+    let remainder =
+      String.sub s remainder_start remainder_length |> String.trim in
+
+    begin
+      if remainder = "" then
+        Some [%expr `Icc ([%e iri], None)]
+      else
+        Some
+          [%expr
+            `Icc ([%e iri], Some [%e _paint_without_icc loc name remainder])]
+    end [@metaloc loc]
+
+let srcset_element =
+  let space = Str.regexp " +" in
+
+  fun ?separated_by ?default loc name s ->
+    let e =
+      begin match Str.bounded_split space s 2 with
+      | [url] ->
+        [%expr `Url [%e Ppx_common.string_exp loc url]]
+
+      | [url; descriptor] ->
+        let bad_descriptor () =
+          Ppx_common.error loc "Bad width or density descriptor in %s" name in
+
+        let url = Ppx_common.string_exp loc url in
+        let suffix_index = String.length descriptor - 1 in
+
+        let is_width =
+          match descriptor.[suffix_index] with
+          | 'w' -> true
+          | 'x' -> false
+          | _ -> bad_descriptor ()
+          | exception Invalid_argument _ -> bad_descriptor ()
+        in
+
+        if is_width then
+          let n =
+            match _int_exp loc (String.sub descriptor 0 suffix_index) with
+            | Some n -> n
+            | None ->
+              Ppx_common.error loc "Bad number for width in %s" name
+          in
+
+          [%expr `Url_width ([%e url], [%e n])]
+
+        else
+          let n =
+            match _float_exp loc (String.sub descriptor 0 suffix_index) with
+            | Some n -> n
+            | None ->
+              Ppx_common.error loc "Bad number for pixel density in %s" name
+          in
+
+          [%expr `Url_pixel ([%e url], [%e n])]
+
+      | _ -> Ppx_common.error loc "Missing URL in %s" name
+      end [@metaloc loc]
+    in
+
+    Some e
+
+
+
+(* Special-cased. *)
+
+let sandbox = spaces variant
+
+let in_ = total_variant Svg_types_reflected.in_value
+
+let in2 = in_
+
+let xmlns ?separated_by ?default loc name s =
+  if s <> Markup.Ns.html then
+    Ppx_common.error loc "%s: namespace must be %s" name Markup.Ns.html;
+
+  Some [%expr `W3_org_1999_xhtml] [@metaloc loc]

--- a/ppx/ppx_attribute_value.ml
+++ b/ppx/ppx_attribute_value.ml
@@ -129,8 +129,7 @@ let int_exp loc s =
 
 let float_exp loc s =
   try
-    float_of_string s |> ignore;
-    Some (Ppx_common.float loc s)
+    Some (Ppx_common.float loc @@ float_of_string s)
   with Failure "float_of_string" ->
     None
 

--- a/ppx/ppx_attribute_value.ml
+++ b/ppx/ppx_attribute_value.ml
@@ -279,41 +279,6 @@ let length =
 
     Some e
 
-(* This is only called by the commas combinator; hence the error message. *)
-let multilength =
-  let regexp = Re_str.regexp "\\([0-9]+\\)\\(%\\|px\\)\\|\\([0-9]+\\)?\\*" in
-
-  fun ?separated_by:_ ?default:_ loc name s ->
-    if not @@ does_match regexp s then
-      Ppx_common.error loc "Value of %s must be a %s"
-        name "list of relative lengths, such as 100px, 50%, or *";
-
-    begin
-      if group_matched 1 s then
-        let n =
-          match int_exp loc (Re_str.matched_group 1 s) with
-          | Some n -> n
-          | None ->
-            Ppx_common.error loc "Value in %s out of range" name
-        in
-
-        match Re_str.matched_group 2 s with
-        | "%" -> Some [%expr `Percent [%e n]]
-        | "px" -> Some [%expr `Pixels [%e n]]
-        | _ -> Ppx_common.error loc "Internal error: Ppx_attribute.multilength"
-
-      else
-        let n =
-          match int_exp loc (Re_str.matched_group 3 s) with
-          | exception Not_found -> [%expr 1]
-          | Some n -> n
-          | None ->
-            Ppx_common.error loc "Relative length in %s out of range" name
-        in
-
-        Some [%expr `Relative [%e n]]
-    end [@metaloc loc]
-
 let svg_quantity =
   let integer = "[+-]?[0-9]+" in
   let integer_scientific = Printf.sprintf "%s\\([Ee]%s\\)?" integer integer in

--- a/ppx/ppx_attribute_value.mli
+++ b/ppx/ppx_attribute_value.mli
@@ -141,14 +141,6 @@ val length : parser
     - [`Pixels i] if [s] has form [(string_of_int i) ^ "px"], or
     - [`Percent i] if [s] has form [(string_of_int i) ^ "%"]. *)
 
-val multilength : parser
-(** [multilength _ _ s] produces a parse tree for
-
-    - [`Pixels i] if [s] has form [(string_of_int i) ^ "px"],
-    - [`Percent i] if [s] has form [(string_of_int i) ^ "%"],
-    - [`Relative i] if [s] has form [(string_of_int i) ^ "*"], or
-    - [`Relative 1] if [s] is ["*"]. *)
-
 val svg_length : parser
 (** [svg_length _ _ s] produces a parse tree for a value of type
     [Svg_types.Unit.(length quantity)]. [s] is expected to have form

--- a/ppx/ppx_attribute_value.mli
+++ b/ppx/ppx_attribute_value.mli
@@ -1,0 +1,210 @@
+(* TyXML
+ * http://www.ocsigen.org/tyxml
+ * Copyright (C) 2016 Anton Bachin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
+*)
+
+(** Attribute value parsers and parser combinators. *)
+
+
+
+type parser =
+  ?separated_by:string -> ?default:string -> Location.t -> string -> string ->
+    Parsetree.expression option
+(** Attribute value parsers are assigned to each attribute depending on the type
+    of the attribute's argument, though some attributes have special parsers
+    based on their name, or on a [[@@reflect]] annotation. A parser is a
+    function [p] such that [p loc name value] either:
+
+    - converts the string [value] into [Some] of a parse tree representing that
+      value, for use with attributes that take an argument, or
+    - evaluates to [None], for use with attributes that take no argument (for
+      instance, [a_selected]).
+
+    For example, [int loc name "3"] converts ["3"] into the parse tree
+    [{pexp_desc = Pexp_constant (Const_int 3); ...}].
+
+    The parse tree is assigned the location [loc]. This {e should} be the
+    location of the start of the value string, but, presently, the location of
+    the element containing the value string is used.
+
+    [name] is the name of the attribute. This is used only for error reporting.
+
+    [~separated_by] and [~default] are used internally by combinators to modify
+    the error message (for example, to make nouns plural if an error occurs in a
+    list). *)
+
+
+
+(** {2 Combinators} *)
+
+val option : string -> parser -> parser
+(** [option none parser _ _ s] behaves as follows:
+
+    - if [s] = [none], evaluates to a parse tree for [None].
+    - otherwise, if [parser _ _ s] evaluates to a parse tree for [e], [option]
+      evaluates to a parse tree for [Some e]. *)
+
+val spaces : parser -> parser
+(** [spaces parser _ _ s] splits [s] on spaces, then applies [parser] to each
+    component. The resulting parse trees for [e, e', ...] are combined into a
+    parse tree fo [[e; e'; ...]]. *)
+
+val commas : parser -> parser
+(** Similar to [spaces], but splits on commas. *)
+
+val semicolons : parser -> parser
+(** Similar to [spaces], but splits on semicolons. *)
+
+val spaces_or_commas : parser -> parser
+(** Similar to [spaces], but splits on both spaces and commas. *)
+
+val wrap : parser -> string -> parser
+(** [wrap parser module_ _ _ s] applies [parser _ _ s] to get a parse tree for
+    [e], then evaluates to the parse tree for [module_.Xml.W.return e]. *)
+
+val nowrap : parser -> string -> parser
+(** [nowrap parser _ _ _ s] evaluates to [parser _ _ s]. The purpose of this
+    combinator is provide a signature similar to [wrap] in situations where
+    wrapping is not wanted. *)
+
+
+
+(** {2 Numeric} *)
+
+val char : parser
+(** [char _ _ s], where [s] is a string containing a single byte [c], produces
+    a parse tree for [c]. *)
+
+val bool : parser
+(** [bool _ _ s] produces a parse tree for the boolean [true] if [s = "true"]
+    and [false] if [s = "false"]. *)
+
+val int : parser
+(** [int _ _ s] produces a parse tree for [int_of_string s]. *)
+
+val float : parser
+(** [float _ _ s] produces a parse tree for [float_of_string s]. This is a
+    slight superset of HTML and SVG decimal fraction number syntax. *)
+
+val points : parser
+(** Similar to [spaces_or_commas float], but pairs consecutive numbers. *)
+
+val number_pair : parser
+(** [number_pair _ _ s] produces a parse tree for
+
+    - [n, None] if [s] = [(string_of_float n)], or
+    - [m, Some n'] if [s] is a space- or comma-separated list of representations
+      of two floats. *)
+
+val fourfloats : parser
+(** Acts as [spaces_or_commas float], but expects the list to have exactly four
+    elements. *)
+
+val icon_size : parser
+(** [icon_size _ _ s] produces a parse tree for the pair [(width, height)] when
+    [s] has the form [(string_of_int width) ^ x ^ (string_of_int height)] and
+    [x] is either ["x"] or ["X"]. *)
+
+
+
+(** {2 Dimensional} *)
+
+val length : parser
+(** [length _ _ s] produces a parse tree for
+
+    - [`Pixels i] if [s] has form [(string_of_int i) ^ "px"], or
+    - [`Percent i] if [s] has form [(string_of_int i) ^ "%"]. *)
+
+val multilength : parser
+(** [multilength _ _ s] produces a parse tree for
+
+    - [`Pixels i] if [s] has form [(string_of_int i) ^ "px"],
+    - [`Percent i] if [s] has form [(string_of_int i) ^ "%"],
+    - [`Relative i] if [s] has form [(string_of_int i) ^ "*"], or
+    - [`Relative 1] if [s] is ["*"]. *)
+
+val svg_length : parser
+(** [svg_length _ _ s] produces a parse tree for a value of type
+    [Svg_types.Unit.(length quantity)]. [s] is expected to have form
+    [(string_of_float n) ^ unit] for some number [n] and a valid SVG length
+    unit, or no unit. *)
+
+val angle : parser
+(** Similar to [svg_length], but for SVG angles. *)
+
+val offset : parser
+(** [offset _ _ s produces a parse tree for
+
+    - [`Number n] if [s] = [string_of_float n], or
+    - [`Percentage i] if [s] has form [(string_of_int i) ^ "%"]. *)
+
+val transform : parser
+(** Parses an SVG transform attribute value. See
+    {:{https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform}
+    transform (MDN)}. *)
+
+
+
+(* {2 String-like} *)
+
+val string : parser
+(** [string _ _ s] produces a parse tree for [s]. This is intended for ordinary
+    attributes containing text that requires no further parsing. *)
+
+val variant : parser
+(** [variant _ _ s] produces a parse tree for the variand
+    [Tyxml_name.polyvar s]. This is intended for attributes whose argument type
+    is a polymorphic variant, none of whose constructors take arguments. *)
+
+val total_variant : (string * string list) -> parser
+(** [total_variant] is used for parsing arguments whose type is a variant with
+    the following pattern:
+
+{[
+| `A | `B | `C | `EverythingElse of string
+]}
+
+    It behaves like [variant] for strings matching the no-argument constructors.
+    Any other string [s] is mapped to the parse trees for
+    [`EverythingElse s]. *)
+
+
+
+(* {2 Miscellaneous} *)
+
+val presence : parser
+(** [presence _ _ _] evaluates to [None]. It is used as a "parser" for
+    attributes that do not take arguments. *)
+
+val paint : parser
+(* Parses SVG paint values. See
+   {:{https://www.w3.org/TR/SVG/painting.html#SpecifyingPaint} Specifying
+   paint}. *)
+
+val srcset_element : parser
+(** Used for [a_srcset]. *)
+
+
+
+(* {2 Special-cased}
+
+    These parsers are named after the attribute for which they are used. *)
+
+val sandbox : parser
+val in_ : parser
+val in2 : parser
+val xmlns : parser

--- a/ppx/ppx_attribute_value.mli
+++ b/ppx/ppx_attribute_value.mli
@@ -20,10 +20,19 @@
 (** Attribute value parsers and parser combinators. *)
 
 
+type value = [
+  | `String of string
+  | `Expr of Parsetree.expression
+]
+(** Values are either an OCaml expression, provided through an antiquotations
+    or a string parser from a literal.
+*)
 
-type parser =
-  ?separated_by:string -> ?default:string -> Location.t -> string -> string ->
-    Parsetree.expression option
+type 'a gparser =
+  ?separated_by:string -> ?default:string -> Location.t -> string -> 'a ->
+  Parsetree.expression option
+and parser = string gparser
+and vparser = value gparser
 (** Attribute value parsers are assigned to each attribute depending on the type
     of the attribute's argument, though some attributes have special parsers
     based on their name, or on a [[@@reflect]] annotation. A parser is a
@@ -72,13 +81,16 @@ val semicolons : parser -> parser
 val spaces_or_commas : parser -> parser
 (** Similar to [spaces], but splits on both spaces and commas. *)
 
-val wrap : parser -> Ppx_common.lang -> parser
+(** {3 Top combinators}
+    Exported parsers should always use one of those combinators last. *)
+
+val wrap : parser -> Ppx_common.lang -> vparser
 (** [wrap parser module_ _ _ s] applies [parser _ _ s] to get a parse tree for
     [e], then evaluates to the parse tree for [module_.Xml.W.return e]. *)
 
-val nowrap : parser -> Ppx_common.lang -> parser
+val nowrap : parser -> Ppx_common.lang -> vparser
 (** [nowrap parser _ _ _ s] evaluates to [parser _ _ s]. The purpose of this
-    combinator is provide a signature similar to [wrap] in situations where
+    combinator is to provide a signature similar to [wrap] in situations where
     wrapping is not wanted. *)
 
 

--- a/ppx/ppx_attribute_value.mli
+++ b/ppx/ppx_attribute_value.mli
@@ -72,11 +72,11 @@ val semicolons : parser -> parser
 val spaces_or_commas : parser -> parser
 (** Similar to [spaces], but splits on both spaces and commas. *)
 
-val wrap : parser -> string -> parser
+val wrap : parser -> Ppx_common.lang -> parser
 (** [wrap parser module_ _ _ s] applies [parser _ _ s] to get a parse tree for
     [e], then evaluates to the parse tree for [module_.Xml.W.return e]. *)
 
-val nowrap : parser -> string -> parser
+val nowrap : parser -> Ppx_common.lang -> parser
 (** [nowrap parser _ _ _ s] evaluates to [parser _ _ s]. The purpose of this
     combinator is provide a signature similar to [wrap] in situations where
     wrapping is not wanted. *)

--- a/ppx/ppx_attributes.ml
+++ b/ppx/ppx_attributes.ml
@@ -129,7 +129,7 @@ let parse loc (ns, element_name) attributes =
   in
 
   let labeled, regular =
-    attributes |> List.fold_left parse_attribute ([], []) in
+    List.fold_left parse_attribute ([], []) attributes in
 
   (* If there are any attributes to pass in ~a, assemble them into a parse tree
      for a list, and prefix that with the ~a label. *)

--- a/ppx/ppx_attributes.ml
+++ b/ppx/ppx_attributes.ml
@@ -1,0 +1,142 @@
+(* TyXML
+ * http://www.ocsigen.org/tyxml
+ * Copyright (C) 2016 Anton Bachin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
+*)
+
+let parse loc (ns, element_name) attributes =
+  let language, implementation, (module Reflected) =
+    Ppx_namespace.reflect loc ns in
+
+  (* For attribute names ["data-foo"], evaluates to [Some "foo"], otherwise
+     evaluates to [None]. *)
+  let parse_user_data local_name =
+    let prefix = "data-" in
+    let length = String.length prefix in
+
+    let is_user_data =
+      try language = "HTML" && String.sub local_name 0 length = prefix
+      with Invalid_argument _ -> false
+    in
+
+    if not is_user_data then None
+    else Some (String.sub local_name length (String.length local_name - length))
+  in
+
+  (* Applied to each attribute. Accumulates individually labeled attributes,
+     such as img/src, in "labeled," and attributes passed in ~a in "regular." *)
+  let parse_attribute (labeled, regular) ((_, local_name), value) =
+    (* Convert the markup name of the attribute to a TyXML name without regard
+       to renamed attributes such as "a_input_max." Renaming will be accounted
+       for later. *)
+    let tyxml_name = Tyxml_name.attrib local_name in
+
+    let test_labeled (e, a, _) = e = element_name && a = local_name in
+    let test_blacklisted (a, _, _) = a = tyxml_name in
+    let test_renamed (_, a, es) = a = local_name && List.mem element_name es in
+
+    let unknown () =
+      Ppx_common.error loc "Unknown attribute in %s element: %s"
+        language local_name
+    in
+
+    (* Check whether this attribute is individually labeled. Parse its argument
+       and accumulate the attribute if so. *)
+    match Ppx_common.find test_labeled Reflected.labeled_attributes with
+    | Some (_, label, parser) ->
+      let e =
+        match parser implementation loc local_name value with
+        | None ->
+          Ppx_common.error loc
+            "Internal error: labeled attribute %s without an argument" label
+        | Some e -> e
+      in
+
+      (label, e)::labeled, regular
+
+    | None ->
+      (* The attribute is not individually labeled, so it is passed in ~a.
+
+         First, check if the default TyXML name of this attribute collides with
+         the TyXML name of a renamed attribute. For example, if the language is
+         HTML, and this attribute has markup name "input-max" (which is
+         invalid), then its default TyXML name will be "a_input_max", which is a
+         *valid* value in TyXML. We want to avoid mapping "input-max" to
+         "a_input_max", because "input-max" is invalid, and because
+         "a_input_max" maps to "max" instead. *)
+      if List.exists test_blacklisted Reflected.renamed_attributes then
+        unknown ()
+      else
+        (* Check if this is a "data-foo" attribute. Parse the attribute value,
+           and accumulate it in the list of attributes passed in ~a. *)
+        match parse_user_data local_name with
+        | Some tag ->
+          let tyxml_name = "a_user_data" in
+
+          let parser =
+            try List.assoc tyxml_name Reflected.attribute_parsers
+            with Not_found ->
+              Ppx_common.error loc "Internal error: no parser for %s" tyxml_name
+          in
+
+          let identifier = Ppx_common.qualify implementation tyxml_name in
+          let identifier = Ppx_common.identifier loc identifier in
+
+          let tag = Ppx_common.string_exp loc tag in
+
+          let e =
+            match parser implementation loc local_name value with
+            | Some e' -> [%expr [%e identifier] [%e tag] [%e e']] [@metaloc loc]
+            | None ->
+              Ppx_common.error loc "Internal error: no expression for %s"
+                tyxml_name
+          in
+
+          labeled, e::regular
+
+        | None ->
+          let tyxml_name =
+            match Ppx_common.find test_renamed Reflected.renamed_attributes with
+            | Some (name, _, _) -> name
+            | None -> tyxml_name
+          in
+
+          let parser =
+            try List.assoc tyxml_name Reflected.attribute_parsers
+            with Not_found -> unknown ()
+          in
+
+          let identifier = Ppx_common.qualify implementation tyxml_name in
+          let identifier = Ppx_common.identifier loc identifier in
+
+          let e =
+            match parser implementation loc local_name value with
+            | None -> identifier
+            | Some e' -> [%expr [%e identifier] [%e e']] [@metaloc loc]
+          in
+
+          labeled, e::regular
+  in
+
+  let labeled, regular =
+    attributes |> List.fold_left parse_attribute ([], []) in
+
+  (* If there are any attributes to pass in ~a, assemble them into a parse tree
+     for a list, and prefix that with the ~a label. *)
+  if regular = [] then List.rev labeled
+  else
+    let regular = "a", Ppx_common.list_exp loc (List.rev regular) in
+    List.rev (regular::labeled)

--- a/ppx/ppx_attributes.mli
+++ b/ppx/ppx_attributes.mli
@@ -1,0 +1,38 @@
+(* TyXML
+ * http://www.ocsigen.org/tyxml
+ * Copyright (C) 2016 Anton Bachin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
+*)
+
+(** Attribute parsing. *)
+
+
+
+val parse :
+  Location.t -> Markup.name -> (Markup.name * string) list ->
+    (Asttypes.label * Parsetree.expression) list
+(** [parse loc element_name attributes] evaluates to a list of labeled parse
+    trees, each representing an attribute argument to the element function for
+    [element_name]. For example, if called on the HTML element
+    [<img src='foo' alt='bar' id='some-image'>], this function will evaluate to
+    parse trees for the arguments:
+
+{[
+~src:(return "foo") ~alt:(return "bar") ~a:[id (return "some-image")]
+]}
+
+    This satisfies the attribute arguments in the signature of
+    [Html5_sigs.T.img]. *)

--- a/ppx/ppx_attributes.mli
+++ b/ppx/ppx_attributes.mli
@@ -22,7 +22,7 @@
 
 
 val parse :
-  Location.t -> Markup.name -> (Markup.name * string) list ->
+  Location.t -> Markup.name -> (Markup.name * Ppx_attribute_value.value) list ->
     (Asttypes.label * Parsetree.expression) list
 (** [parse loc element_name attributes] evaluates to a list of labeled parse
     trees, each representing an attribute argument to the element function for

--- a/ppx/ppx_common.ml
+++ b/ppx/ppx_common.ml
@@ -24,27 +24,39 @@ let find f l =
   try Some (List.find f l)
   with Not_found -> None
 
-let int_exp loc n = Exp.constant ~loc (Const_int n)
+let int loc n = Exp.constant ~loc (Const_int n)
 
-let float_exp loc s = Exp.constant ~loc (Const_float s)
+let float loc s = Exp.constant ~loc (Const_float s)
 
-let string_exp loc s = Exp.constant ~loc (Const_string (s, None))
+let string loc s = Exp.constant ~loc (Const_string (s, None))
 
 let identifier loc s = Exp.ident ~loc (Location.mkloc (Longident.parse s) loc)
 
-let list_exp loc l =
+let list loc l =
   (l |> List.rev |> List.fold_left (fun acc tree ->
     [%expr [%e tree]::[%e acc]])
     [%expr []]) [@metaloc loc]
 
 let error loc fmt = Location.raise_errorf ~loc ("Error: "^^fmt)
 
+type lang = Html | Svg
+
 let html5_implementation = "Html5"
 let svg_implementation = "Svg"
 
+let implementation = function
+  | Html -> html5_implementation
+  | Svg -> svg_implementation
+
+let lang = function
+  | Html -> "HTML"
+  | Svg -> "SVG"
+
 let qualify module_ identifier = Printf.sprintf "%s.%s" module_ identifier
 
-let wrap_exp implementation loc e =
+let make ~loc i s = identifier loc (qualify (implementation i) s)
+
+let wrap implementation loc e =
   [%expr
-    [%e identifier loc (qualify implementation "Xml.W.return")]
+    [%e make ~loc implementation "Xml.W.return"]
     [%e e]] [@metaloc loc]

--- a/ppx/ppx_common.ml
+++ b/ppx/ppx_common.ml
@@ -24,12 +24,18 @@ module Label = Ast_convenience.Label
 
 type lang = Html | Svg
 
-let html5_implementation = "Html5"
-let svg_implementation = "Svg"
+let html5_implementation = ref "Html5"
+let svg_implementation = ref "Svg"
 
-let implementation = function
+let implemenentation_ref = function
   | Html -> html5_implementation
   | Svg -> svg_implementation
+
+let set_implementation lang s =
+  (implemenentation_ref lang) := s
+
+let implementation lang =
+  !(implemenentation_ref lang)
 
 let lang = function
   | Html -> "HTML"

--- a/ppx/ppx_common.ml
+++ b/ppx/ppx_common.ml
@@ -35,9 +35,9 @@ let lang = function
   | Html -> "HTML"
   | Svg -> "SVG"
 
-let qualify module_ identifier = Printf.sprintf "%s.%s" module_ identifier
-let identifier loc s = Exp.ident ~loc (Location.mkloc (Longident.parse s) loc)
-let make ~loc i s = identifier loc (qualify (implementation i) s)
+let make ~loc i s =
+  let lid = Longident.parse @@ implementation i ^ "." ^ s in
+  Exp.ident ~loc @@ Location.mkloc lid loc
 
 (** Generic *)
 

--- a/ppx/ppx_common.ml
+++ b/ppx/ppx_common.ml
@@ -17,18 +17,22 @@
  * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
 *)
 
-open Asttypes
 open Ast_helper
+
+module Label = Ast_convenience.Label
 
 let find f l =
   try Some (List.find f l)
   with Not_found -> None
 
-let int loc n = Exp.constant ~loc (Const_int n)
+let with_loc loc f x =
+  with_default_loc loc @@ fun () -> f x
 
-let float loc s = Exp.constant ~loc (Const_float s)
+let int loc = with_loc loc Ast_convenience.int
 
-let string loc s = Exp.constant ~loc (Const_string (s, None))
+let float loc = with_loc loc Ast_convenience.float
+
+let string loc = with_loc loc Ast_convenience.str
 
 let identifier loc s = Exp.ident ~loc (Location.mkloc (Longident.parse s) loc)
 

--- a/ppx/ppx_common.ml
+++ b/ppx/ppx_common.ml
@@ -37,9 +37,7 @@ let list_exp loc l =
     [%expr [%e tree]::[%e acc]])
     [%expr []]) [@metaloc loc]
 
-let error loc =
-  Printf.ksprintf
-    (fun s -> raise (Location.Error (Location.error ~loc ("Error: " ^ s))))
+let error loc fmt = Location.raise_errorf ~loc ("Error: "^^fmt)
 
 let html5_implementation = "Html5"
 let svg_implementation = "Svg"

--- a/ppx/ppx_common.ml
+++ b/ppx/ppx_common.ml
@@ -1,0 +1,52 @@
+(* TyXML
+ * http://www.ocsigen.org/tyxml
+ * Copyright (C) 2016 Anton Bachin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
+*)
+
+open Asttypes
+open Ast_helper
+
+let find f l =
+  try Some (List.find f l)
+  with Not_found -> None
+
+let int_exp loc n = Exp.constant ~loc (Const_int n)
+
+let float_exp loc s = Exp.constant ~loc (Const_float s)
+
+let string_exp loc s = Exp.constant ~loc (Const_string (s, None))
+
+let identifier loc s = Exp.ident ~loc (Location.mkloc (Longident.parse s) loc)
+
+let list_exp loc l =
+  (l |> List.rev |> List.fold_left (fun acc tree ->
+    [%expr [%e tree]::[%e acc]])
+    [%expr []]) [@metaloc loc]
+
+let error loc =
+  Printf.ksprintf
+    (fun s -> raise (Location.Error (Location.error ~loc ("Error: " ^ s))))
+
+let html5_implementation = "Html5"
+let svg_implementation = "Svg"
+
+let qualify module_ identifier = Printf.sprintf "%s.%s" module_ identifier
+
+let wrap_exp implementation loc e =
+  [%expr
+    [%e identifier loc (qualify implementation "Xml.W.return")]
+    [%e e]] [@metaloc loc]

--- a/ppx/ppx_common.mli
+++ b/ppx/ppx_common.mli
@@ -38,6 +38,7 @@ val int : Location.t -> int -> Parsetree.expression
 val float : Location.t -> float -> Parsetree.expression
 val string : Location.t -> string -> Parsetree.expression
 val list : Location.t -> Parsetree.expression list -> Parsetree.expression
+val list_wrap : lang -> Location.t -> Parsetree.expression list -> Parsetree.expression
 
 val wrap :
   lang -> Location.t -> Parsetree.expression -> Parsetree.expression

--- a/ppx/ppx_common.mli
+++ b/ppx/ppx_common.mli
@@ -1,0 +1,53 @@
+(* TyXML
+ * http://www.ocsigen.org/tyxml
+ * Copyright (C) 2016 Anton Bachin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
+*)
+
+val find : ('a -> bool) -> 'a list -> 'a option
+(** Similar to [List.find], but evaluates to an option instead of raising
+    [Not_found]. *)
+
+
+
+(** Expression helpers. *)
+
+val int_exp : Location.t -> int -> Parsetree.expression
+val float_exp : Location.t -> string -> Parsetree.expression
+val string_exp : Location.t -> string -> Parsetree.expression
+val identifier : Location.t -> string -> Parsetree.expression
+val list_exp : Location.t -> Parsetree.expression list -> Parsetree.expression
+
+val wrap_exp :
+  string -> Location.t -> Parsetree.expression -> Parsetree.expression
+(** [wrap_exp implementation loc e] creates a parse tree for
+    [implementation.Xml.W.return e]. *)
+
+
+
+val error : Location.t -> ('b, unit, string, 'a) format4 -> 'b
+(** Raises an error using compiler module [Location]. *)
+
+
+
+val html5_implementation : string
+(** The module name ["Html5"]. *)
+
+val svg_implementation : string
+(** The module name ["Svg"]. *)
+
+val qualify : string -> string -> string
+(** [qualify m i] is [m ^ "." ^ i]. *)

--- a/ppx/ppx_common.mli
+++ b/ppx/ppx_common.mli
@@ -21,6 +21,7 @@ val find : ('a -> bool) -> 'a list -> 'a option
 (** Similar to [List.find], but evaluates to an option instead of raising
     [Not_found]. *)
 
+module Label = Ast_convenience.Label
 
 (** Markup language *)
 
@@ -34,7 +35,7 @@ val make :
 (** Expression helpers. *)
 
 val int : Location.t -> int -> Parsetree.expression
-val float : Location.t -> string -> Parsetree.expression
+val float : Location.t -> float -> Parsetree.expression
 val string : Location.t -> string -> Parsetree.expression
 val list : Location.t -> Parsetree.expression list -> Parsetree.expression
 

--- a/ppx/ppx_common.mli
+++ b/ppx/ppx_common.mli
@@ -28,6 +28,7 @@ module Label = Ast_convenience.Label
 type lang = Html | Svg
 val lang : lang -> string
 val implementation : lang -> string
+val set_implementation : lang -> string -> unit
 
 val make :
   loc:Location.t -> lang -> string -> Parsetree.expression

--- a/ppx/ppx_common.mli
+++ b/ppx/ppx_common.mli
@@ -36,7 +36,6 @@ val make :
 val int : Location.t -> int -> Parsetree.expression
 val float : Location.t -> string -> Parsetree.expression
 val string : Location.t -> string -> Parsetree.expression
-val identifier : Location.t -> string -> Parsetree.expression
 val list : Location.t -> Parsetree.expression list -> Parsetree.expression
 
 val wrap :
@@ -46,6 +45,3 @@ val wrap :
 
 val error : Location.t -> ('b, unit, string, 'a) format4 -> 'b
 (** Raises an error using compiler module [Location]. *)
-
-val qualify : string -> string -> string
-(** [qualify m i] is [m ^ "." ^ i]. *)

--- a/ppx/ppx_common.mli
+++ b/ppx/ppx_common.mli
@@ -22,32 +22,30 @@ val find : ('a -> bool) -> 'a list -> 'a option
     [Not_found]. *)
 
 
+(** Module implementations *)
+
+type lang = Html | Svg
+val lang : lang -> string
+val implementation : lang -> string
+
+val make :
+  loc:Location.t -> lang -> string -> Parsetree.expression
 
 (** Expression helpers. *)
 
-val int_exp : Location.t -> int -> Parsetree.expression
-val float_exp : Location.t -> string -> Parsetree.expression
-val string_exp : Location.t -> string -> Parsetree.expression
+val int : Location.t -> int -> Parsetree.expression
+val float : Location.t -> string -> Parsetree.expression
+val string : Location.t -> string -> Parsetree.expression
 val identifier : Location.t -> string -> Parsetree.expression
-val list_exp : Location.t -> Parsetree.expression list -> Parsetree.expression
+val list : Location.t -> Parsetree.expression list -> Parsetree.expression
 
-val wrap_exp :
-  string -> Location.t -> Parsetree.expression -> Parsetree.expression
+val wrap :
+  lang -> Location.t -> Parsetree.expression -> Parsetree.expression
 (** [wrap_exp implementation loc e] creates a parse tree for
     [implementation.Xml.W.return e]. *)
 
-
-
 val error : Location.t -> ('b, unit, string, 'a) format4 -> 'b
 (** Raises an error using compiler module [Location]. *)
-
-
-
-val html5_implementation : string
-(** The module name ["Html5"]. *)
-
-val svg_implementation : string
-(** The module name ["Svg"]. *)
 
 val qualify : string -> string -> string
 (** [qualify m i] is [m ^ "." ^ i]. *)

--- a/ppx/ppx_common.mli
+++ b/ppx/ppx_common.mli
@@ -22,7 +22,7 @@ val find : ('a -> bool) -> 'a list -> 'a option
     [Not_found]. *)
 
 
-(** Module implementations *)
+(** Markup language *)
 
 type lang = Html | Svg
 val lang : lang -> string

--- a/ppx/ppx_element.ml
+++ b/ppx/ppx_element.ml
@@ -17,24 +17,23 @@
  * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
 *)
 
-let parse loc ((ns, name) as element_name) attributes children =
-  let attributes = Ppx_attributes.parse loc element_name attributes in
+let parse ~loc ~name:((ns, name) as element_name) ~attributes children =
 
-  let language, (module Reflected) =
-    Ppx_namespace.reflect loc ns in
+  let attributes = Ppx_attributes.parse loc element_name attributes in
+  let lang, (module Reflected) = Ppx_namespace.reflect loc ns in
 
   let name =
     try List.assoc name Reflected.renamed_elements
     with Not_found -> name
   in
-  let element_function = Ppx_common.make ~loc language name in
+  let element_function = Ppx_common.make ~loc lang name in
 
   let assembler =
     try List.assoc name Reflected.element_assemblers
     with Not_found ->
-      Ppx_common.error loc "Unknown %s element %s" (Ppx_common.lang language) name
+      Ppx_common.error loc "Unknown %s element %s" (Ppx_common.lang lang) name
   in
 
-  let children = assembler language loc name children in
+  let children = assembler ~lang ~loc ~name children in
 
   Ast_helper.Exp.apply ~loc element_function (attributes @ children)

--- a/ppx/ppx_element.ml
+++ b/ppx/ppx_element.ml
@@ -1,0 +1,43 @@
+(* TyXML
+ * http://www.ocsigen.org/tyxml
+ * Copyright (C) 2016 Anton Bachin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
+*)
+
+let parse loc ((ns, name) as element_name) attributes children =
+  let attributes = Ppx_attributes.parse loc element_name attributes in
+
+  let language, implementation, (module Reflected) =
+    Ppx_namespace.reflect loc ns in
+
+  let name =
+    try List.assoc name Reflected.renamed_elements
+    with Not_found -> name
+  in
+
+  let element_function =
+    Ppx_common.qualify implementation name
+    |> Ppx_common.identifier loc
+  in
+
+  let assembler =
+    try List.assoc name Reflected.element_assemblers
+    with Not_found -> Ppx_common.error loc "Unknown %s element %s" language name
+  in
+
+  let children = assembler implementation loc name children in
+
+  Ast_helper.Exp.apply ~loc element_function (attributes @ children)

--- a/ppx/ppx_element.ml
+++ b/ppx/ppx_element.ml
@@ -37,3 +37,10 @@ let parse ~loc ~name:((ns, name) as element_name) ~attributes children =
   let children = assembler ~lang ~loc ~name children in
 
   Ast_helper.Exp.apply ~loc element_function (attributes @ children)
+
+let comment ~loc ~lang s =
+  let tot = Ppx_common.make ~loc lang "tot" in
+  let comment = Ppx_common.make ~loc lang "Xml.comment" in
+  let s = Ppx_common.string loc s in
+  (* Using metaquot here avoids fiddling with labels. *)
+  [%expr [%e tot] ([%e comment] [%e s])][@metaloc loc]

--- a/ppx/ppx_element.ml
+++ b/ppx/ppx_element.ml
@@ -20,24 +20,21 @@
 let parse loc ((ns, name) as element_name) attributes children =
   let attributes = Ppx_attributes.parse loc element_name attributes in
 
-  let language, implementation, (module Reflected) =
+  let language, (module Reflected) =
     Ppx_namespace.reflect loc ns in
 
   let name =
     try List.assoc name Reflected.renamed_elements
     with Not_found -> name
   in
-
-  let element_function =
-    Ppx_common.qualify implementation name
-    |> Ppx_common.identifier loc
-  in
+  let element_function = Ppx_common.make ~loc language name in
 
   let assembler =
     try List.assoc name Reflected.element_assemblers
-    with Not_found -> Ppx_common.error loc "Unknown %s element %s" language name
+    with Not_found ->
+      Ppx_common.error loc "Unknown %s element %s" (Ppx_common.lang language) name
   in
 
-  let children = assembler implementation loc name children in
+  let children = assembler language loc name children in
 
   Ast_helper.Exp.apply ~loc element_function (attributes @ children)

--- a/ppx/ppx_element.mli
+++ b/ppx/ppx_element.mli
@@ -19,12 +19,12 @@
 
 (** Element parsing. *)
 
-
-
 val parse :
-  Location.t ->
-  Markup.name -> (Markup.name * string) list -> Parsetree.expression list ->
-    Parsetree.expression
-(** [parse loc name attributes children] evaluates to a parse tree for applying
+  loc:Location.t ->
+  name:Markup.name ->
+  attributes:(Markup.name * string) list ->
+  Parsetree.expression list ->
+  Parsetree.expression
+(** [parse ~loc ~name ~attributes children] evaluates to a parse tree for applying
     the TyXML function corresponding to element [name] to suitable arguments
     representing [attributes] and [children]. *)

--- a/ppx/ppx_element.mli
+++ b/ppx/ppx_element.mli
@@ -28,3 +28,10 @@ val parse :
 (** [parse ~loc ~name ~attributes children] evaluates to a parse tree for applying
     the TyXML function corresponding to element [name] to suitable arguments
     representing [attributes] and [children]. *)
+
+val comment :
+  loc:Location.t ->
+  lang:Ppx_common.lang ->
+  string ->
+  Parsetree.expression
+(** [comment ~loc ~ns s] evaluates to a parse tree that represents an XML comment. *)

--- a/ppx/ppx_element.mli
+++ b/ppx/ppx_element.mli
@@ -1,0 +1,30 @@
+(* TyXML
+ * http://www.ocsigen.org/tyxml
+ * Copyright (C) 2016 Anton Bachin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
+*)
+
+(** Element parsing. *)
+
+
+
+val parse :
+  Location.t ->
+  Markup.name -> (Markup.name * string) list -> Parsetree.expression list ->
+    Parsetree.expression
+(** [parse loc name attributes children] evaluates to a parse tree for applying
+    the TyXML function corresponding to element [name] to suitable arguments
+    representing [attributes] and [children]. *)

--- a/ppx/ppx_element.mli
+++ b/ppx/ppx_element.mli
@@ -22,7 +22,7 @@
 val parse :
   loc:Location.t ->
   name:Markup.name ->
-  attributes:(Markup.name * string) list ->
+  attributes:(Markup.name * Ppx_attribute_value.value) list ->
   Parsetree.expression list ->
   Parsetree.expression
 (** [parse ~loc ~name ~attributes children] evaluates to a parse tree for applying

--- a/ppx/ppx_element_content.ml
+++ b/ppx/ppx_element_content.ml
@@ -57,20 +57,10 @@ let qualify_child lang = function
    argument [implementation] is as in [_qualify_child]. Applies [_qualify_child]
    to each child, then assembles the children into a parse tree representing a
    value of type [_ implementation.list_wrap]. *)
-let list_wrap_exp implementation loc es =
-  let nil =
-    [%expr
-      [%e Pc.make ~loc implementation "Xml.W.nil"]
-      ()] [@metaloc loc]
-  in
-  let cons = Pc.make ~loc implementation "Xml.W.cons" in
-
+let list_wrap_exp lang loc es =
   es
-  |> List.map (qualify_child implementation)
-  |> List.rev
-  |> List.fold_left (fun wrapped e ->
-    [%expr [%e cons] [%e e] [%e wrapped]] [@metaloc loc])
-    nil
+  |> List.map (qualify_child lang)
+  |> Pc.list_wrap lang loc
 
 (* Given a list of parse trees representing children of an element, filters out
    all children that consist of applications of [pcdata] to strings containing

--- a/ppx/ppx_element_content.ml
+++ b/ppx/ppx_element_content.ml
@@ -45,11 +45,9 @@ let qualify_child lang = function
     [%expr [%e identifier] [%e s]] [@metaloc e.pexp_loc]
 
   | {pexp_desc =
-      Pexp_apply ({pexp_desc = Pexp_ident lid} as e', arguments)} as e
+      Pexp_apply ({pexp_desc = Pexp_ident lid}, arguments)} as e
       when Longident.last lid.txt = "svg" && lang = Html ->
-    let html5_svg = Ppx_common.qualify Ppx_common.(implementation Html) "svg" in
-    let lid = {lid with txt = Longident.parse html5_svg} in
-    let identifier = {e' with pexp_desc = Pexp_ident lid} in
+    let identifier = Ppx_common.make ~loc:lid.loc Html "svg" in
     {e with pexp_desc = Pexp_apply (identifier, arguments)}
 
   | e -> e
@@ -86,7 +84,7 @@ let filter_whitespace children =
    application of a function with name [name]. *)
 let is_element_with_name name = function
   | {pexp_desc = Pexp_apply ({pexp_desc = Pexp_ident {txt}}, _)}
-      when Longident.flatten txt |> String.concat "." = name -> true
+      when txt = name -> true
   | _ -> false
 
 (* Partitions a list of elements according to [_is_element_with_name name]. *)
@@ -96,7 +94,7 @@ let partition name children =
 (* Given the name [n] of a function in [Html5_sigs.T], evaluates to
    ["Html5." ^ n]. *)
 let html5 local_name =
-  Ppx_common.qualify Ppx_common.(implementation Html) local_name
+  Longident.Ldot (Lident Ppx_common.(implementation Html), local_name)
 
 
 

--- a/ppx/ppx_element_content.ml
+++ b/ppx/ppx_element_content.ml
@@ -1,0 +1,262 @@
+(* TyXML
+ * http://www.ocsigen.org/tyxml
+ * Copyright (C) 2016 Anton Bachin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
+*)
+
+open Asttypes
+open Parsetree
+
+
+
+type assembler =
+  string -> Location.t -> string -> Parsetree.expression list ->
+    (Asttypes.label * Parsetree.expression) list
+
+
+
+(* Helpers. *)
+
+(* Called on a parse tree representing a child of an element. The argument
+   [implementation] is the module name (string) ["Html5"] if the parent element
+   is in the HTML namespace, and ["Svg"] if the parent is in the SVG namespace.
+
+   - If the child is an unqualified application of the function [pcdata],
+     qualifies it with the module [implementation].
+   - If [implementation] is ["Html5"] and the child is an application of [svg]
+     from any module, modifies the child to be an application of [Html5.svg]
+   - Otherwise, evaluates to the child as passed. *)
+let _qualify_child implementation = function
+  | [%expr pcdata [%e ? s]] as e ->
+    let identifier =
+      Ppx_common.identifier e.pexp_loc
+        (Ppx_common.qualify implementation "pcdata")
+    in
+    [%expr [%e identifier] [%e s]] [@metaloc e.pexp_loc]
+
+  | {pexp_desc =
+      Pexp_apply ({pexp_desc = Pexp_ident lid} as e', arguments)} as e
+      when Longident.last lid.txt = "svg"
+        && implementation = Ppx_common.html5_implementation ->
+    let html5_svg = Ppx_common.qualify Ppx_common.html5_implementation "svg" in
+    let lid = {lid with txt = Longident.parse html5_svg} in
+    let identifier = {e' with pexp_desc = Pexp_ident lid} in
+    {e with pexp_desc = Pexp_apply (identifier, arguments)}
+
+  | e -> e
+
+(* Called on a list of parse trees representing children of an element. The
+   argument [implementation] is as in [_qualify_child]. Applies [_qualify_child]
+   to each child, then assembles the children into a parse tree representing a
+   value of type [_ implementation.list_wrap]. *)
+let _list_wrap_exp implementation loc es =
+  let nil =
+    [%expr
+      [%e Ppx_common.identifier loc
+        (Ppx_common.qualify implementation "Xml.W.nil")]
+      ()] [@metaloc loc]
+  in
+  let cons =
+    Ppx_common.identifier loc
+      (Ppx_common.qualify implementation "Xml.W.cons")
+  in
+
+  es
+  |> List.map (_qualify_child implementation)
+  |> List.rev
+  |> List.fold_left (fun wrapped e ->
+    [%expr [%e cons] [%e e] [%e wrapped]] [@metaloc loc])
+    nil
+
+(* Given a list of parse trees representing children of an element, filters out
+   all children that consist of applications of [pcdata] to strings containing
+   only whitespace. *)
+let _filter_whitespace children =
+  children |> List.filter (function
+    | [%expr pcdata [%e ? {pexp_desc = Pexp_constant (Const_string (s, _))}]]
+        when String.trim s = "" -> false
+    | _ -> true)
+
+(* Given a parse tree and a string [name], checks whether the parse tree is an
+   application of a function with name [name]. *)
+let _is_element_with_name name = function
+  | {pexp_desc = Pexp_apply ({pexp_desc = Pexp_ident {txt}}, _)}
+      when Longident.flatten txt |> String.concat "." = name -> true
+  | _ -> false
+
+(* Partitions a list of elements according to [_is_element_with_name name]. *)
+let _partition name children =
+  List.partition (_is_element_with_name name) children
+
+(* Given the name [n] of a function in [Html5_sigs.T], evaluates to
+   ["Html5." ^ n]. *)
+let _html5 local_name =
+  Ppx_common.qualify Ppx_common.html5_implementation local_name
+
+
+
+(* Generic. *)
+
+let nullary _ loc name children =
+  if children <> [] then
+    Ppx_common.error loc "%s should have no content" name;
+  ["", [%expr ()] [@metaloc loc]]
+
+let unary implementation loc name children =
+  match children with
+  | [child] ->
+    let child =
+      _qualify_child implementation child
+      |> Ppx_common.wrap_exp implementation loc
+    in
+    ["", child]
+  | _ -> Ppx_common.error loc "%s should have exactly one child" name
+
+let star implementation loc _ children =
+  ["", _list_wrap_exp implementation loc children]
+
+
+
+(* Special-cased. *)
+
+let html implementation loc name children =
+  let children = _filter_whitespace children in
+  let head, others = _partition (_html5 "head") children in
+  let body, others = _partition (_html5 "body") others in
+
+  match head, body, others with
+  | [head], [body], [] ->
+    ["", Ppx_common.wrap_exp implementation loc head;
+     "", Ppx_common.wrap_exp implementation loc body]
+  | _ ->
+    Ppx_common.error loc
+      "%s element must have exactly head and body child elements" name
+
+let head implementation loc name children =
+  let title, others = _partition (_html5 "title") children in
+
+  match title with
+  | [title] ->
+    ("", Ppx_common.wrap_exp implementation loc title)::
+      (star implementation loc name others)
+  | _ ->
+    Ppx_common.error loc
+      "%s element must have exactly one title child element" name
+
+let figure implementation loc name children =
+  begin match children with
+  | [] -> star implementation loc name children
+  | first::others ->
+    if _is_element_with_name (_html5 "figcaption") first then
+      ("figcaption",
+       [%expr `Top [%e Ppx_common.wrap_exp implementation loc first]])::
+          (star implementation loc name others)
+    else
+      let children_reversed = List.rev children in
+      let last = List.hd children_reversed in
+      if _is_element_with_name (_html5 "figcaption") last then
+        let others = List.rev (List.tl children_reversed) in
+        ("figcaption",
+         [%expr `Bottom [%e Ppx_common.wrap_exp implementation loc last]])::
+            (star implementation loc name others)
+      else
+        star implementation loc name children
+  end [@metaloc loc]
+
+let object_ implementation loc name children =
+  let params, others = _partition (_html5 "param") children in
+
+  if params <> [] then
+    ("params", _list_wrap_exp implementation loc params)::
+      (star implementation loc name others)
+  else
+    star implementation loc name others
+
+let audio_video implementation loc name children =
+  let sources, others = _partition (_html5 "source") children in
+
+  if sources <> [] then
+    ("srcs", _list_wrap_exp implementation loc sources)::
+      (star implementation loc name others)
+  else
+    star implementation loc name others
+
+let table implementation loc name children =
+  let caption, others = _partition (_html5 "caption") children in
+  let columns, others = _partition (_html5 "colgroup") others in
+  let thead, others = _partition (_html5 "thead") others in
+  let tfoot, others = _partition (_html5 "tfoot") others in
+
+  let one label = function
+    | [] -> []
+    | [child] -> [label, Ppx_common.wrap_exp implementation loc child]
+    | _ -> Ppx_common.error loc "%s cannot have more than one %s" name label
+  in
+
+  let columns =
+    if columns = [] then []
+    else ["columns", _list_wrap_exp implementation loc columns]
+  in
+
+  (one "caption" caption) @
+    columns @
+    (one "thead" thead) @
+    (one "tfoot" tfoot) @
+    (star implementation loc name others)
+
+let fieldset implementation loc name children =
+  let legend, others = _partition (_html5 "legend") children in
+
+  match legend with
+  | [] -> star implementation loc name others
+  | [legend] ->
+    ("legend", Ppx_common.wrap_exp implementation loc legend)::
+      (star implementation loc name others)
+  | _ -> Ppx_common.error loc "%s cannot have more than one legend" name
+
+let datalist implementation loc name children =
+  let options, others = _partition (_html5 "option") children in
+
+  let children =
+    begin match others with
+    | [] ->
+      "children",
+      [%expr `Options [%e _list_wrap_exp implementation loc options]]
+
+    | _ ->
+      "children",
+      [%expr `Phras [%e _list_wrap_exp implementation loc children]]
+    end [@metaloc loc]
+  in
+
+  children::(nullary implementation loc name [])
+
+let details implementation loc name children =
+  let summary, others = _partition (_html5 "summary") children in
+
+  match summary with
+  | [summary] ->
+    ("", Ppx_common.wrap_exp implementation loc summary)::
+      (star implementation loc name others)
+  | _ -> Ppx_common.error loc "%s must have exactly one summary child" name
+
+let menu implementation loc name children =
+  let children =
+    "child",
+    [%expr `Flows [%e _list_wrap_exp implementation loc children]]
+      [@metaloc loc]
+  in
+  children::(nullary implementation loc name [])

--- a/ppx/ppx_element_content.ml
+++ b/ppx/ppx_element_content.ml
@@ -40,7 +40,7 @@ type assembler =
      from any module, modifies the child to be an application of [Html5.svg]
    - Otherwise, evaluates to the child as passed. *)
 let _qualify_child implementation = function
-  | [%expr pcdata [%e ? s]] as e ->
+  | [%expr pcdata [%e? s]] as e ->
     let identifier =
       Ppx_common.identifier e.pexp_loc
         (Ppx_common.qualify implementation "pcdata")
@@ -86,7 +86,7 @@ let _list_wrap_exp implementation loc es =
    only whitespace. *)
 let _filter_whitespace children =
   children |> List.filter (function
-    | [%expr pcdata [%e ? {pexp_desc = Pexp_constant (Const_string (s, _))}]]
+    | [%expr pcdata [%e? {pexp_desc = Pexp_constant (Const_string (s, _))}]]
         when String.trim s = "" -> false
     | _ -> true)
 

--- a/ppx/ppx_element_content.mli
+++ b/ppx/ppx_element_content.mli
@@ -1,0 +1,82 @@
+(* TyXML
+ * http://www.ocsigen.org/tyxml
+ * Copyright (C) 2016 Anton Bachin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
+*)
+
+(** Element child argument assemblers. These are almost parsers, except they
+    only tell how to pass already-parsed children to element functions. *)
+
+
+
+type assembler =
+  string -> Location.t -> string -> Parsetree.expression list ->
+    (Asttypes.label * Parsetree.expression) list
+(** Assemblers satisfy: [assembler implementation loc name children] evaluates
+    to a list of optionally-labeled parse trees for passing [children] to the
+    the element function for element [name]. For example, for a table element
+
+{[
+<table>
+  <thead>
+    <tr><th>A</th><th>B</th></tr>
+  </thead>
+  <tbody>
+  </tbody>
+</table>
+]}
+
+    The assembler [table], when called with the parsed children, will evaluate
+    to parse trees representing
+
+{[
+~thead:(* the thead element *) [(* the tbody element *)]
+]}
+
+    This satisfies the child arguments in the signature of
+    [Html5_sigs.T.tablex]. The [~table] label is represented by the string
+    ["table"], and the unlabeled list argument is paired with the empty string.
+
+    The argument [implementation] is the name of the module providing the
+    run-time implementation of the element function that will be applied to the
+    children. It is either [Html5] or [Svg], and is based on the element's
+    namespace. It is used for wrapping child elements, and for scoping child
+    [pcdata] elements.
+
+    The [name] argument is used for error reporting. *)
+
+
+
+(** {2 Generic} *)
+
+val nullary : assembler
+val unary : assembler
+val star : assembler
+
+
+
+(** {2 Special-cased} *)
+
+val html : assembler
+val head : assembler
+val figure : assembler
+val object_ : assembler
+val audio_video : assembler
+val table : assembler
+val fieldset : assembler
+val datalist : assembler
+val details : assembler
+val menu : assembler

--- a/ppx/ppx_element_content.mli
+++ b/ppx/ppx_element_content.mli
@@ -23,7 +23,7 @@
 
 
 type assembler =
-  string -> Location.t -> string -> Parsetree.expression list ->
+  Ppx_common.lang -> Location.t -> string -> Parsetree.expression list ->
     (Asttypes.label * Parsetree.expression) list
 (** Assemblers satisfy: [assembler implementation loc name children] evaluates
     to a list of optionally-labeled parse trees for passing [children] to the

--- a/ppx/ppx_element_content.mli
+++ b/ppx/ppx_element_content.mli
@@ -20,12 +20,13 @@
 (** Element child argument assemblers. These are almost parsers, except they
     only tell how to pass already-parsed children to element functions. *)
 
-
-
 type assembler =
-  Ppx_common.lang -> Location.t -> string -> Parsetree.expression list ->
-    (Asttypes.label * Parsetree.expression) list
-(** Assemblers satisfy: [assembler implementation loc name children] evaluates
+  lang:Ppx_common.lang ->
+  loc:Location.t ->
+  name:string ->
+  Parsetree.expression list ->
+  (Ppx_common.Label.t * Parsetree.expression) list
+(** Assemblers satisfy: [assembler ~lang ~loc ~name children] evaluates
     to a list of optionally-labeled parse trees for passing [children] to the
     the element function for element [name]. For example, for a table element
 
@@ -58,15 +59,11 @@ type assembler =
 
     The [name] argument is used for error reporting. *)
 
-
-
 (** {2 Generic} *)
 
 val nullary : assembler
 val unary : assembler
 val star : assembler
-
-
 
 (** {2 Special-cased} *)
 

--- a/ppx/ppx_namespace.ml
+++ b/ppx/ppx_namespace.ml
@@ -1,0 +1,31 @@
+(* TyXML
+ * http://www.ocsigen.org/tyxml
+ * Copyright (C) 2016 Anton Bachin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
+*)
+
+let reflect loc = function
+  | ns when ns = Markup.Ns.html ->
+    "HTML",
+    Ppx_common.html5_implementation,
+    (module Html5_sigs_reflected : Ppx_sigs_reflected.S)
+
+  | ns when ns = Markup.Ns.svg ->
+    "SVG",
+    Ppx_common.svg_implementation,
+    (module Svg_sigs_reflected : Ppx_sigs_reflected.S)
+
+  | ns -> Ppx_common.error loc "Unknown namespace %s" ns

--- a/ppx/ppx_namespace.ml
+++ b/ppx/ppx_namespace.ml
@@ -19,13 +19,9 @@
 
 let reflect loc = function
   | ns when ns = Markup.Ns.html ->
-    "HTML",
-    Ppx_common.html5_implementation,
-    (module Html5_sigs_reflected : Ppx_sigs_reflected.S)
+    Ppx_common.Html ,(module Html5_sigs_reflected : Ppx_sigs_reflected.S)
 
   | ns when ns = Markup.Ns.svg ->
-    "SVG",
-    Ppx_common.svg_implementation,
-    (module Svg_sigs_reflected : Ppx_sigs_reflected.S)
+    Ppx_common.Svg, (module Svg_sigs_reflected : Ppx_sigs_reflected.S)
 
   | ns -> Ppx_common.error loc "Unknown namespace %s" ns

--- a/ppx/ppx_namespace.ml
+++ b/ppx/ppx_namespace.ml
@@ -17,11 +17,14 @@
  * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
 *)
 
-let reflect loc = function
-  | ns when ns = Markup.Ns.html ->
-    Ppx_common.Html ,(module Html5_sigs_reflected : Ppx_sigs_reflected.S)
+let get : Ppx_common.lang -> (module Ppx_sigs_reflected.S) = function
+  | Html -> (module Html5_sigs_reflected)
+  | Svg  -> (module Svg_sigs_reflected)
 
-  | ns when ns = Markup.Ns.svg ->
-    Ppx_common.Svg, (module Svg_sigs_reflected : Ppx_sigs_reflected.S)
+let to_lang loc ns =
+  if ns = Markup.Ns.html then Ppx_common.Html
+  else if ns = Markup.Ns.svg then Ppx_common.Svg
+  else Ppx_common.error loc "Unknown namespace %s" ns
 
-  | ns -> Ppx_common.error loc "Unknown namespace %s" ns
+let reflect loc ns =
+  let l = to_lang loc ns in (l, get l)

--- a/ppx/ppx_namespace.mli
+++ b/ppx/ppx_namespace.mli
@@ -27,3 +27,9 @@ val reflect :
     to the title of the corresponding markup language, the name of the run-time
     module containing its TyXML implementation, and a preprocessing-time module
     containing reflection information. *)
+
+val get : Ppx_common.lang -> (module Ppx_sigs_reflected.S)
+(** Similar to {!reflect} but takes a {!Ppx_common.lang} directly. *)
+
+val to_lang : Location.t -> string -> Ppx_common.lang
+(** Takes a namespace and returns the appropriate language. *)

--- a/ppx/ppx_namespace.mli
+++ b/ppx/ppx_namespace.mli
@@ -1,0 +1,29 @@
+(* TyXML
+ * http://www.ocsigen.org/tyxml
+ * Copyright (C) 2016 Anton Bachin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
+*)
+
+(** Namespace-specific values. *)
+
+
+
+val reflect :
+  Location.t -> string -> string * string * (module Ppx_sigs_reflected.S)
+(** When given either [Markup.Ns.html] or [Markup.Ns.svg] as argument, evaluates
+    to the title of the corresponding markup language, the name of the run-time
+    module containing its TyXML implementation, and a preprocessing-time module
+    containing reflection information. *)

--- a/ppx/ppx_namespace.mli
+++ b/ppx/ppx_namespace.mli
@@ -22,7 +22,7 @@
 
 
 val reflect :
-  Location.t -> string -> string * string * (module Ppx_sigs_reflected.S)
+  Location.t -> string -> Ppx_common.lang * (module Ppx_sigs_reflected.S)
 (** When given either [Markup.Ns.html] or [Markup.Ns.svg] as argument, evaluates
     to the title of the corresponding markup language, the name of the run-time
     module containing its TyXML implementation, and a preprocessing-time module

--- a/ppx/ppx_reflect.ml
+++ b/ppx/ppx_reflect.ml
@@ -124,9 +124,6 @@ let rec to_attribute_parser name = function
   | [[%type : length]] ->
     [%expr length]
 
-  | [[%type : multilengths]] ->
-    [%expr commas multilength]
-
   | [[%type : coord]] | [[%type : Unit.length]] ->
     [%expr svg_length]
 

--- a/ppx/ppx_reflect.ml
+++ b/ppx/ppx_reflect.ml
@@ -1,0 +1,471 @@
+(* TyXML
+ * http://www.ocsigen.org/tyxml
+ * Copyright (C) 2016 Anton Bachin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
+*)
+
+(* Runs on [html5_sigs.mli], [svg_sigs.mli], and [html5_types.mli]. Certain type
+   and value declarations are read for type information, which is stored in
+   corresponding [_reflected] files - for example, [html5_sigs.mli] results in
+   [html5_sigs_reflected.ml]. See comments by functions below and in
+   [ppx_sigs_reflected.mli] for details. *)
+
+open Ast_mapper
+open Asttypes
+open Parsetree
+
+
+
+let is_attribute s = String.length s >= 2 && String.sub s 0 2 = "a_"
+
+let strip_a s =
+  if String.length s < 2 || String.sub s 0 2 <> "a_" then s
+  else String.sub s 2 (String.length s - 2)
+
+let argument_types t =
+  let rec scan acc = function
+    | Ptyp_arrow (_, t, t') -> scan (t::acc) t'.ptyp_desc
+    | _ -> List.rev acc
+  in
+  scan [] t.ptyp_desc
+
+
+
+(* Given the name of a TyXML attribute function and a list of its argument
+   types, selects the attribute value parser (in module [Ppx_attribute_value])
+   that should be used for that attribute. *)
+let type_to_attribute_parser name types =
+  let rec no_constructor_arguments = function
+    | [] -> true
+    | (Rinherit _)::_
+    | (Rtag (_, _, _, _::_))::_ -> false
+    | (Rtag (_, _, _, []))::more -> no_constructor_arguments more
+  in
+
+  match types with
+  | [] ->
+    "nowrap presence"
+
+  | [[%type : character wrap]] ->
+    "wrap char"
+
+  | [[%type : bool wrap]] ->
+    "wrap bool"
+
+  | [[%type : number wrap]]
+  | [[%type : pixels wrap]]
+  | [[%type : int wrap]] ->
+    "wrap int"
+
+  | [[%type : numbers wrap]] ->
+    "wrap (commas int)"
+
+  | [[%type : float_number wrap]]
+  | [[%type : float wrap]] ->
+    "wrap float"
+
+  | [[%type : float_number option wrap]] ->
+    "wrap (option \"any\" float)"
+
+  | [[%type : numbers_semicolon wrap]] ->
+    "wrap (semicolons float)"
+
+  | [[%type : fourfloats wrap]] ->
+    "wrap fourfloats"
+
+  | [[%type : number_optional_number wrap]] ->
+    "wrap number_pair"
+
+  | [[%type : coords wrap]] ->
+    "wrap points"
+
+  | [[%type : (number * number) list option wrap]] ->
+    "wrap (option \"any\" (spaces icon_size))"
+
+  | [[%type : length wrap]] ->
+    "wrap length"
+
+  | [[%type : multilengths wrap]] ->
+    "wrap (commas multilength)"
+
+  | [[%type : coord wrap]]
+  | [[%type : Unit.length wrap]] ->
+    "wrap svg_length"
+
+  | [[%type : Unit.length list wrap]] ->
+    "wrap (spaces_or_commas svg_length)"
+
+  | [[%type : Unit.angle option wrap]] ->
+    "wrap (option \"auto\" angle)"
+
+  | [[%type : string wrap]]
+  | [[%type : text wrap]]
+  | [[%type : nmtoken wrap]]
+  | [[%type : idref wrap]]
+  | [[%type : Xml.uri wrap]]
+  | [[%type : contenttype wrap]]
+  | [[%type : languagecode wrap]]
+  | [[%type : cdata wrap]]
+  | [[%type : charset wrap]]
+  | [[%type : frametarget wrap]]
+  | [[%type : iri wrap]]
+  | [[%type : color wrap]]
+  | [[%type : nmtoken]; [%type : text wrap]] ->
+    "wrap string"
+
+  | [[%type : Xml.event_handler]]
+  | [[%type : Xml.mouse_event_handler]]
+  | [[%type : Xml.keyboard_event_handler]] ->
+    "nowrap string"
+
+  | [[%type : string option wrap]] ->
+    "wrap (option \"\" string)"
+
+  | [[%type :
+      [%t ? {ptyp_desc = Ptyp_variant (_::_::_ as constructors, _, _)}] wrap]]
+      when no_constructor_arguments constructors ->
+    "wrap variant"
+
+  | [[%type : shape wrap]] ->
+    "wrap variant"
+
+  | [[%type : nmtokens wrap]]
+  | [[%type : idrefs wrap]]
+  | [[%type : charsets wrap]]
+  | [[%type : spacestrings wrap]]
+  | [[%type : strings wrap]] ->
+    "wrap (spaces string)"
+
+  | [[%type : commastrings wrap]]
+  | [[%type : text list wrap]]
+  | [[%type : contenttypes wrap]] ->
+    "wrap (commas string)"
+
+  | [[%type : linktypes wrap]] ->
+    "wrap (spaces (total_variant Html5_types_reflected.linktype))"
+
+  | [[%type : mediadesc wrap]] ->
+    "wrap (commas (total_variant Html5_types_reflected.mediadesc_token))"
+
+  | [[%type : transform wrap]] ->
+    "wrap transform"
+
+  | [[%type : lengths wrap]] ->
+    "wrap (spaces_or_commas svg_length)"
+
+  | [[%type : transforms wrap]] ->
+    "wrap (spaces_or_commas transform)"
+
+  | [[%type : paint wrap]] ->
+    "wrap paint"
+
+  | [[%type : image_candidate list wrap]] ->
+    "wrap (commas srcset_element)"
+
+  | _ ->
+    let name = strip_a name in
+    let name = if name = "in" then "in_" else name in
+    Printf.sprintf "wrap %s" name
+
+(* Given a list of attributes from a val declaration whose name begins with a_,
+   checks if the declaration has a [@@reflect.attribute] annotation. If so, the
+   declaration's name does not directly correspond to markup attribute name
+   (e.g. "a_input_max" does not directly correspond to "max"). The annotation is
+   parsed to get the markup name and the element types in which the translation
+   from markup name to TyXML name should be performed. *)
+let ocaml_attributes_to_renamed_attribute name attributes =
+  let maybe_attribute =
+    attributes
+    |> Ppx_common.find (fun attr -> (fst attr).txt = "reflect.attribute")
+  in
+
+  match maybe_attribute with
+  | None -> []
+  | Some ({loc}, payload) ->
+    match payload with
+    | PStr [%str
+        [%e ? {pexp_desc = Pexp_constant (Const_string (real_name, _))}]
+        [%e ? element_names]] ->
+      let element_names =
+        let rec traverse acc = function
+          | [%expr
+              [%e ? {pexp_desc =
+                Pexp_constant (Const_string (element_name, _))}]::
+                  [%e ? tail]] ->
+            traverse (element_name::acc) tail
+          | [%expr []] -> acc
+          | {pexp_loc} ->
+            Ppx_common.error pexp_loc
+              "List in [@@reflect.attribute] must contain strings"
+        in
+        traverse [] element_names
+      in
+
+      [name, real_name, element_names]
+
+    | _ ->
+      Ppx_common.error loc
+        "Payload of [@@reflect.attribute] must be a string and a string list"
+
+(* Given a val declaration, determines whether it is for an element. If so,
+   evaluates to the element's child assembler (from module
+   [Ppx_element_content]), list of attributes passed as labeled arguments, and
+   markup name, if different from its TyXML name (for example, [object_] is
+   [object] in markup).
+
+   A val declaration is for an element if it either has a [@@reflect.element]
+   attribute, or its result type is [_ nullary], [_ unary], or [_ star]. *)
+let val_item_to_element_info value_description =
+  let name = value_description.pval_name.txt in
+
+  let maybe_attribute =
+    value_description.pval_attributes
+    |> Ppx_common.find (fun attr -> (fst attr).txt = "reflect.element")
+  in
+
+  let maybe_assembler, real_name =
+    match maybe_attribute with
+    | Some ({loc}, payload) ->
+      begin match payload with
+      | PStr [%str
+          [%e ? {pexp_desc = Pexp_constant (Const_string (assembler, _))}]] ->
+        Some assembler, None
+
+      | PStr [%str
+          [%e ? {pexp_desc = Pexp_constant (Const_string (assembler, _))}]
+          [%e ? {pexp_desc = Pexp_constant (Const_string (name, _))}]] ->
+        Some assembler, Some name
+
+      | _ ->
+        Ppx_common.error loc
+          "Payload of [@@reflect.element] must be a one or two strings"
+      end
+
+    | None ->
+      let result_type =
+        let rec scan = function
+          | {ptyp_desc = Ptyp_arrow (_, _, t')} -> scan t'
+          | t -> t
+        in
+        scan value_description.pval_type
+      in
+
+      match result_type with
+      | [%type : ([%t ? _], [%t ? _]) nullary] -> Some "nullary", None
+      | [%type : ([%t ? _], [%t ? _], [%t ? _]) unary] -> Some "unary", None
+      | [%type : ([%t ? _], [%t ? _], [%t ? _]) star] -> Some "star", None
+      | _ -> None, None
+  in
+
+  match maybe_assembler with
+  | None -> None
+  | Some assembler ->
+    let labeled_attributes =
+      let rec scan acc = function
+        | Ptyp_arrow (label, t, t') ->
+          let label =
+            if label = "" || label.[0] <> '?' then label
+            else String.sub label 1 (String.length label - 1)
+          in
+          if label = "" then scan acc t'.ptyp_desc
+          else begin
+            let maybe_attribute_type =
+              match t with
+              | [%type : [%t ? _] wrap] ->
+                Some t
+
+              | {ptyp_desc = Ptyp_constr (lid, [[%type : [%t ? _] elt wrap]])}
+                  when Longident.last lid.txt = "option" ->
+                None
+
+              | {ptyp_desc =
+                  Ptyp_constr (lid, [[%type : [%t ? _] wrap] as t''])}
+                  when Longident.last lid.txt = "option" ->
+                Some t''
+
+              | _ ->
+                None
+            in
+
+            match maybe_attribute_type with
+            | None -> scan acc t'.ptyp_desc
+            | Some t'' ->
+              let parser = type_to_attribute_parser label [t''] in
+              scan ((name, label, parser)::acc) t'.ptyp_desc
+          end
+
+        | _ -> acc
+      in
+      scan [] value_description.pval_type.ptyp_desc
+    in
+
+    let rename =
+      match real_name with
+      | None -> []
+      | Some real_name -> [real_name, name]
+    in
+
+    Some (assembler, labeled_attributes, rename)
+
+
+
+let attribute_parsers = ref []
+let labeled_attributes = ref []
+let renamed_attributes = ref []
+let element_assemblers = ref []
+let renamed_elements = ref []
+
+(* Walks over signature items, looking for elements and attributes. Calls the
+   functions immediately above, and accumulates their results in the above
+   references. This function is relevant for [html5_sigs.mli] and
+   [svg_sigs.mli]. *)
+let signature_item mapper item =
+  begin match item.psig_desc with
+  | Psig_value {pval_name = {txt = name}; pval_type = type_; pval_attributes}
+      when is_attribute name ->
+    (* Attribute declaration. *)
+
+    let argument_types = argument_types type_ in
+    let attribute_parser_mapping =
+      name, type_to_attribute_parser name argument_types in
+    attribute_parsers := attribute_parser_mapping::!attribute_parsers;
+
+    let renaming = ocaml_attributes_to_renamed_attribute name pval_attributes in
+    renamed_attributes := renaming @ !renamed_attributes
+
+  | Psig_value v ->
+    (* Non-attribute, but potentially an element declaration. *)
+
+    begin match val_item_to_element_info v with
+    | None -> ()
+    | Some (assembler, labeled_attributes', rename) ->
+      element_assemblers := (v.pval_name.txt, assembler)::!element_assemblers;
+      labeled_attributes := labeled_attributes' @ !labeled_attributes;
+      renamed_elements := rename @ !renamed_elements
+    end
+
+  | _ -> ()
+  end;
+
+  default_mapper.signature_item mapper item
+
+
+
+let reflected_variants = ref []
+
+(* Walks over type declarations (which will be in signature items). For each
+   that is marked with [@@reflect.total_variant], expects it to be a polymorphic
+   variant. Splits the constructors into those that have no arguments, and one
+   constructor that has one string argument. This constructor information is
+   accumulated in [reflected_variants]. This function is relevant for
+   [html5_types.mli]. *)
+let type_declaration mapper declaration =
+  let is_reflect attr = (fst attr).txt = "reflect.total_variant" in
+  if List.exists is_reflect declaration.ptype_attributes then begin
+    let name = declaration.ptype_name.txt in
+
+    match declaration.ptype_manifest with
+    | Some {ptyp_desc = Ptyp_variant (rows, _, _); ptyp_loc} ->
+      let rows =
+        rows |> List.map (function
+          | Rtag (label, _, _, types) -> label, types
+          | Rinherit {ptyp_loc} ->
+            Ppx_common.error ptyp_loc
+              "Inclusion is not supported by [@@refect.total_variant]")
+      in
+
+      let nullary, unary =
+        rows |> List.partition (fun (_, types) -> types = []) in
+
+      let unary =
+        match unary with
+        | [name, [[%type : string]]] -> name
+        | _ ->
+          Ppx_common.error ptyp_loc
+            "Expected exactly one non-nullary constructor `C of string"
+      in
+
+      let nullary = nullary |> List.map fst in
+
+      reflected_variants := (name, (unary, nullary))::!reflected_variants
+
+    | _ ->
+      Ppx_common.error declaration.ptype_loc
+        "[@@reflect.total_variant] expects a polymorphic variant type"
+  end;
+
+  default_mapper.type_declaration mapper declaration
+
+
+
+(* Creates an AST mapper that applies [signature_item] and [type_declaration],
+   then formats the generated reflection information as ML code to the file
+   whose name is given in the first argument to the PPX reflector. *)
+let () =
+  if Array.length Sys.argv < 2 then begin
+    Printf.eprintf "Usage: %s FILE\n" Sys.argv.(0);
+    exit 2
+  end;
+
+  let filename = Sys.argv.(1) in
+
+  register "reflect_sig" (fun _ ->
+    {default_mapper with signature_item; type_declaration});
+
+  (* The channel will be closed on process exit. *)
+  let channel = open_out filename in
+  let write f = Printf.fprintf channel f in
+
+  if !attribute_parsers <> [] then begin
+    write "open Ppx_attribute_value\n";
+
+    write "\nlet attribute_parsers = [\n";
+    !attribute_parsers |> List.iter (fun (name, parser) ->
+      write "  %S, %s;\n" name parser);
+    write "]\n";
+
+    write "\nlet renamed_attributes = [\n";
+    !renamed_attributes |> List.iter (fun (name, real_name, element_names) ->
+      write "  %S, %S, [" name real_name;
+      element_names
+      |> List.map (Printf.sprintf "%S")
+      |> String.concat "; "
+      |> write "%s];\n");
+    write "]\n";
+
+    write "\nlet labeled_attributes = [\n";
+    !labeled_attributes |> List.iter (fun (name, label, parser) ->
+      write "  %S, %S, %s;\n" name label parser);
+    write "]\n";
+
+    write "\nopen Ppx_element_content\n";
+
+    write "\nlet element_assemblers = [\n";
+    !element_assemblers |> List.iter (fun (name, assembler) ->
+      write "  %S, %s;\n" name assembler);
+    write "]\n";
+
+    write "\nlet renamed_elements = [\n";
+    !renamed_elements |> List.iter (fun (real_name, name) ->
+      write "  %S, %S;\n" real_name name);
+    write "]\n"
+  end;
+
+  !reflected_variants |> List.iter (fun (name, (unary, nullary)) ->
+    write "\nlet %s = %S, [\n" name unary;
+    nullary |> List.iter (fun nullary ->
+      write "  %S;\n" nullary);
+    write "]\n")

--- a/ppx/ppx_reflect.ml
+++ b/ppx/ppx_reflect.ml
@@ -188,8 +188,8 @@ let type_to_attribute_parser name types =
    from markup name to TyXML name should be performed. *)
 let ocaml_attributes_to_renamed_attribute name attributes =
   let maybe_attribute =
-    attributes
-    |> Ppx_common.find (fun attr -> (fst attr).txt = "reflect.attribute")
+    Ppx_common.find (fun attr -> (fst attr).txt = "reflect.attribute")
+      attributes
   in
 
   match maybe_attribute with
@@ -238,8 +238,8 @@ let val_item_to_element_info value_description =
   let name = value_description.pval_name.txt in
 
   let maybe_attribute =
-    value_description.pval_attributes
-    |> Ppx_common.find (fun attr -> (fst attr).txt = "reflect.element")
+    Ppx_common.find (fun attr -> (fst attr).txt = "reflect.element")
+      value_description.pval_attributes
   in
 
   let maybe_assembler, real_name =
@@ -388,7 +388,7 @@ let type_declaration mapper declaration =
       in
 
       let nullary, unary =
-        rows |> List.partition (fun (_, types) -> types = []) in
+        List.partition (fun (_, types) -> types = []) rows in
 
       let unary =
         match unary with
@@ -398,7 +398,7 @@ let type_declaration mapper declaration =
             "Expected exactly one non-nullary constructor `C of string"
       in
 
-      let nullary = nullary |> List.map fst in
+      let nullary = List.map fst nullary in
 
       reflected_variants := (name, (unary, nullary))::!reflected_variants
 

--- a/ppx/ppx_reflect.ml
+++ b/ppx/ppx_reflect.ml
@@ -135,7 +135,7 @@ let type_to_attribute_parser name types =
     "wrap (option \"\" string)"
 
   | [[%type :
-      [%t ? {ptyp_desc = Ptyp_variant (_::_::_ as constructors, _, _)}] wrap]]
+      [%t? {ptyp_desc = Ptyp_variant (_::_::_ as constructors, _, _)}] wrap]]
       when no_constructor_arguments constructors ->
     "wrap variant"
 
@@ -197,14 +197,14 @@ let ocaml_attributes_to_renamed_attribute name attributes =
   | Some ({loc}, payload) ->
     match payload with
     | PStr [%str
-        [%e ? {pexp_desc = Pexp_constant (Const_string (real_name, _))}]
-        [%e ? element_names]] ->
+        [%e? {pexp_desc = Pexp_constant (Const_string (real_name, _))}]
+        [%e? element_names]] ->
       let element_names =
         let rec traverse acc = function
           | [%expr
-              [%e ? {pexp_desc =
+              [%e? {pexp_desc =
                 Pexp_constant (Const_string (element_name, _))}]::
-                  [%e ? tail]] ->
+                  [%e? tail]] ->
             traverse (element_name::acc) tail
           | [%expr []] -> acc
           | {pexp_loc} ->
@@ -241,12 +241,12 @@ let val_item_to_element_info value_description =
     | Some ({loc}, payload) ->
       begin match payload with
       | PStr [%str
-          [%e ? {pexp_desc = Pexp_constant (Const_string (assembler, _))}]] ->
+          [%e? {pexp_desc = Pexp_constant (Const_string (assembler, _))}]] ->
         Some assembler, None
 
       | PStr [%str
-          [%e ? {pexp_desc = Pexp_constant (Const_string (assembler, _))}]
-          [%e ? {pexp_desc = Pexp_constant (Const_string (name, _))}]] ->
+          [%e? {pexp_desc = Pexp_constant (Const_string (assembler, _))}]
+          [%e? {pexp_desc = Pexp_constant (Const_string (name, _))}]] ->
         Some assembler, Some name
 
       | _ ->
@@ -264,9 +264,9 @@ let val_item_to_element_info value_description =
       in
 
       match result_type with
-      | [%type : ([%t ? _], [%t ? _]) nullary] -> Some "nullary", None
-      | [%type : ([%t ? _], [%t ? _], [%t ? _]) unary] -> Some "unary", None
-      | [%type : ([%t ? _], [%t ? _], [%t ? _]) star] -> Some "star", None
+      | [%type : ([%t? _], [%t ? _]) nullary] -> Some "nullary", None
+      | [%type : ([%t? _], [%t ? _], [%t ? _]) unary] -> Some "unary", None
+      | [%type : ([%t? _], [%t ? _], [%t ? _]) star] -> Some "star", None
       | _ -> None, None
   in
 
@@ -284,15 +284,15 @@ let val_item_to_element_info value_description =
           else begin
             let maybe_attribute_type =
               match t with
-              | [%type : [%t ? _] wrap] ->
+              | [%type : [%t? _] wrap] ->
                 Some t
 
-              | {ptyp_desc = Ptyp_constr (lid, [[%type : [%t ? _] elt wrap]])}
+              | {ptyp_desc = Ptyp_constr (lid, [[%type : [%t? _] elt wrap]])}
                   when Longident.last lid.txt = "option" ->
                 None
 
               | {ptyp_desc =
-                  Ptyp_constr (lid, [[%type : [%t ? _] wrap] as t''])}
+                  Ptyp_constr (lid, [[%type : [%t? _] wrap] as t''])}
                   when Longident.last lid.txt = "option" ->
                 Some t''
 

--- a/ppx/ppx_sigs_reflected.mli
+++ b/ppx/ppx_sigs_reflected.mli
@@ -24,14 +24,15 @@
 
 module type S =
 sig
-  val attribute_parsers : (string * (string -> Ppx_attribute_value.parser)) list
+  val attribute_parsers :
+    (string * (Ppx_common.lang -> Ppx_attribute_value.parser)) list
   (** Pairs [tyxml_attribute_name, wrapped_attribute_value_parser]. *)
 
   val renamed_attributes : (string * string * string list) list
   (** Triples [tyxml_attribute_name, markup_name, in_element_types]. *)
 
   val labeled_attributes :
-    (string * string * (string -> Ppx_attribute_value.parser)) list
+    (string * string * (Ppx_common.lang -> Ppx_attribute_value.parser)) list
   (** Triples [tyxml_element_name, label, wrapped_attribute_value_parser]. *)
 
   val element_assemblers : (string * Ppx_element_content.assembler) list

--- a/ppx/ppx_sigs_reflected.mli
+++ b/ppx/ppx_sigs_reflected.mli
@@ -1,0 +1,42 @@
+(* TyXML
+ * http://www.ocsigen.org/tyxml
+ * Copyright (C) 2016 Anton Bachin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
+*)
+
+(** Signature of [Html5_sigs_reflected] and [Svg_sigs_reflected] (but not
+    [Html5_types_reflected]). *)
+
+
+
+module type S =
+sig
+  val attribute_parsers : (string * (string -> Ppx_attribute_value.parser)) list
+  (** Pairs [tyxml_attribute_name, wrapped_attribute_value_parser]. *)
+
+  val renamed_attributes : (string * string * string list) list
+  (** Triples [tyxml_attribute_name, markup_name, in_element_types]. *)
+
+  val labeled_attributes :
+    (string * string * (string -> Ppx_attribute_value.parser)) list
+  (** Triples [tyxml_element_name, label, wrapped_attribute_value_parser]. *)
+
+  val element_assemblers : (string * Ppx_element_content.assembler) list
+  (** Pairs [tyxml_element_name, child_argument_assembler]. *)
+
+  val renamed_elements : (string * string) list
+  (** Pairs [markup_element_name, tyxml_name]. *)
+end

--- a/ppx/ppx_sigs_reflected.mli
+++ b/ppx/ppx_sigs_reflected.mli
@@ -25,14 +25,14 @@
 module type S =
 sig
   val attribute_parsers :
-    (string * (Ppx_common.lang -> Ppx_attribute_value.parser)) list
+    (string * (Ppx_common.lang -> Ppx_attribute_value.vparser)) list
   (** Pairs [tyxml_attribute_name, wrapped_attribute_value_parser]. *)
 
   val renamed_attributes : (string * string * string list) list
   (** Triples [tyxml_attribute_name, markup_name, in_element_types]. *)
 
   val labeled_attributes :
-    (string * string * (Ppx_common.lang -> Ppx_attribute_value.parser)) list
+    (string * string * (Ppx_common.lang -> Ppx_attribute_value.vparser)) list
   (** Triples [tyxml_element_name, label, wrapped_attribute_value_parser]. *)
 
   val element_assemblers : (string * Ppx_element_content.assembler) list

--- a/ppx/ppx_tyxml.ml
+++ b/ppx/ppx_tyxml.ml
@@ -172,7 +172,7 @@ let markup_to_expr loc expr =
       assemble ();
       let children = !current_children in
 
-      let node = Ppx_element.parse loc name attributes children in
+      let node = Ppx_element.parse ~loc ~name ~attributes children in
 
       current_children := node::accumulator;
       assemble ()

--- a/ppx/ppx_tyxml.ml
+++ b/ppx/ppx_tyxml.ml
@@ -148,7 +148,7 @@ let markup_to_expr loc expr =
         let message = Markup.Error.to_string error |> String.capitalize in
         Ppx_common.error loc "%s" message)
   in
-  let signals = parser |> Markup.signals in
+  let signals = Markup.signals parser in
 
   let rec assemble () =
     match Markup.next signals with

--- a/ppx/ppx_tyxml.ml
+++ b/ppx/ppx_tyxml.ml
@@ -85,6 +85,7 @@ let markup_to_expr loc expr =
     let strings_and_antiquotations =
       expressions |> List.map (fun expr ->
         match expr.pexp_desc with
+        (* TODO: Doesn't work in 4.03, can't pattern match. *)
         | Pexp_constant (Const_string (s, maybe_delimiter)) ->
           let delimiter_length =
             match maybe_delimiter with

--- a/ppx/ppx_tyxml.ml
+++ b/ppx/ppx_tyxml.ml
@@ -67,7 +67,7 @@ let adjust_location start_loc delimiter_length consumed (line, column) =
    reads the Markup.ml signal (output) stream and recursively assembles the
    TyXML expression.
 
-   The current implementation stores the child list in a reference, becuase it
+   The current implementation stores the child list in a reference, because it
    is modified by both the assembler and the input stream function. A better
    implementation would scan the payload for the locations of literal TyXML
    expressions, and merge them into the child list in the assembler. *)

--- a/ppx/ppx_tyxml.ml
+++ b/ppx/ppx_tyxml.ml
@@ -157,7 +157,7 @@ let markup_to_expr loc expr =
     | Some (`Text ss) ->
       let loc = parser |> Markup.location |> !current_adjust_location in
       let node =
-        [%expr pcdata [%e Ppx_common.string_exp loc (String.concat "" ss)]]
+        [%expr pcdata [%e Ppx_common.string loc (String.concat "" ss)]]
           [@metaloc loc]
       in
       current_children := node::!current_children;
@@ -181,7 +181,7 @@ let markup_to_expr loc expr =
   in
 
   assemble ();
-  Ppx_common.list_exp loc !current_children
+  Ppx_common.list loc !current_children
 
 
 

--- a/ppx/ppx_tyxml.ml
+++ b/ppx/ppx_tyxml.ml
@@ -1,0 +1,205 @@
+(* TyXML
+ * http://www.ocsigen.org/tyxml
+ * Copyright (C) 2016 Anton Bachin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
+*)
+
+open Asttypes
+open Parsetree
+
+
+
+(* Converts a Markup.ml input location into an OCaml location. [start_loc] is
+   the OCaml location of the string being parsed by Markup.ml.
+   [delimiter_length] is the length of string delimiter. For a regular string,
+   this is [1] (for the quote). For a delimited string, it is the length of the
+   delimiter plus two for the [{] and [|] characters. [consumed] is the number
+   of bytes consumed by Markup.ml before the beginning of the current string.
+   [(line, column)] is the Markup.ml location to be converted. *)
+let adjust_location start_loc delimiter_length consumed (line, column) =
+  let open Location in
+  let open Lexing in
+
+  let column =
+    if line <> 1 then column
+    else
+      start_loc.loc_start.pos_cnum - start_loc.loc_start.pos_bol +
+        column + delimiter_length - consumed
+  in
+  let line = start_loc.loc_start.pos_lnum + line - 1 in
+
+  let position =
+    {pos_fname = start_loc.loc_start.pos_fname;
+     pos_lnum  = line;
+     pos_bol   = 0;
+     pos_cnum  = column};
+  in
+
+  {loc_start = position;
+   loc_end = position;
+   loc_ghost = false}
+
+(* Given the payload of a [%tyxml ...] expression, converts it to a TyXML
+   expression representing the markup contained therein.
+
+   The payload [expr] is either a single string, or an application expression
+   involving strings and literal TyXML expressions.
+
+   [markup_to_expr] first converts the payload to a list of strings and TyXML
+   expressions. It then builds an input stream for Markup.ml, which walks this
+   list. Bytes in strings encountered are passed to Markup.ml. When a TyXML
+   expression is encountered, it is appended to the current child list.
+
+   The current child list is a piece of state maintained by the assembler, which
+   reads the Markup.ml signal (output) stream and recursively assembles the
+   TyXML expression.
+
+   The current implementation stores the child list in a reference, becuase it
+   is modified by both the assembler and the input stream function. A better
+   implementation would scan the payload for the locations of literal TyXML
+   expressions, and merge them into the child list in the assembler. *)
+let markup_to_expr loc expr =
+  let current_adjust_location = ref (adjust_location Location.none 0 0) in
+  let current_children = ref [] in
+
+  let input_stream =
+    let expressions =
+      match expr.pexp_desc with
+      | Pexp_apply (f, arguments) -> f::(List.map snd arguments)
+      | _ -> [expr]
+    in
+
+    let strings_and_antiquotations =
+      expressions |> List.map (fun expr ->
+        match expr.pexp_desc with
+        | Pexp_constant (Const_string (s, maybe_delimiter)) ->
+          let delimiter_length =
+            match maybe_delimiter with
+            | None -> 1
+            | Some d -> String.length d + 2
+          in
+          `String (s, expr.pexp_loc, delimiter_length)
+
+        | _ ->
+          `Expression expr)
+    in
+
+    let items = ref strings_and_antiquotations in
+    let offset = ref 0 in
+    let consumed = ref 0 in
+
+    let rec next () =
+      match !items with
+      | (`String (s, loc, delimiter_length))::rest ->
+        if !offset = 0 then begin
+          current_adjust_location :=
+            adjust_location loc delimiter_length !consumed;
+          consumed := !consumed + String.length s
+        end;
+
+        if !offset < String.length s then begin
+          offset := !offset + 1;
+          Some (s.[!offset - 1])
+        end
+        else begin
+          offset := 0;
+          items := rest;
+          next ()
+        end
+
+      | (`Expression expr)::rest ->
+        current_children := expr::!current_children;
+        items := rest;
+        next ()
+
+      | [] ->
+        None
+    in
+
+    Markup.fn next
+  in
+
+  (* The encoding is specified as a workaround: when not specified, Markup.ml
+     prescans the input looking for byte-order marks or <meta> tags. We don't
+     want a prescan, because that will trigger premature insertion of literal
+     TyXML expressions into the initial, empty, child list, by the input stream,
+     before the expression assembler starts running. This is fragile and will be
+     fixed by merging TyXML expressions in the assembler instead of as now. *)
+  let parser =
+    input_stream
+    |> Markup.parse_html
+      ~encoding:Markup.Encoding.utf_8
+      ~report:(fun loc error ->
+        let loc = !current_adjust_location loc in
+        let message = Markup.Error.to_string error |> String.capitalize in
+        Ppx_common.error loc "%s" message)
+  in
+  let signals = parser |> Markup.signals in
+
+  let rec assemble () =
+    match Markup.next signals with
+    | None | Some `End_element ->
+      current_children := List.rev !current_children
+
+    | Some (`Text ss) ->
+      let loc = parser |> Markup.location |> !current_adjust_location in
+      let node =
+        [%expr pcdata [%e Ppx_common.string_exp loc (String.concat "" ss)]]
+          [@metaloc loc]
+      in
+      current_children := node::!current_children;
+      assemble ()
+
+    | Some (`Start_element (name, attributes)) ->
+      let loc = parser |> Markup.location |> !current_adjust_location in
+
+      let accumulator = !current_children in
+      current_children := [];
+      assemble ();
+      let children = !current_children in
+
+      let node = Ppx_element.parse loc name attributes children in
+
+      current_children := node::accumulator;
+      assemble ()
+
+    | Some _ ->
+      assemble ()
+  in
+
+  assemble ();
+  Ppx_common.list_exp loc !current_children
+
+
+
+open Ast_mapper
+
+let map_expr mapper e =
+  match e.pexp_desc with
+  | Pexp_extension ({txt = "tyxml"; loc}, payload) ->
+    begin match payload with
+    | PStr [{pstr_desc = Pstr_eval (e, _)}] ->
+      markup_to_expr loc e
+    | _ ->
+      Ppx_common.error e.pexp_loc
+        "Error: Payload of [%%tyxml] must be a single string"
+    end
+  | _ -> default_mapper.expr mapper e
+
+
+
+let () =
+  register "tyxml" (fun _ -> {default_mapper with expr = map_expr})

--- a/ppx/ppx_tyxml.ml
+++ b/ppx/ppx_tyxml.ml
@@ -252,7 +252,7 @@ let markup_to_expr loc expr =
     | Some (`Comment s) ->
       [Ppx_element.comment ~loc ~lang s]
 
-    | Some _ ->
+    | Some (`Xml _ | `Doctype _ | `PI _)  ->
       assemble lang children
   in
 

--- a/ppx/ppx_tyxml.ml
+++ b/ppx/ppx_tyxml.ml
@@ -20,7 +20,94 @@
 open Asttypes
 open Parsetree
 
+(** Antiquotations
 
+    We replace antiquotations expressions by a dummy token "(tyxmlX)".
+    We store a table token to expression to retrieve them after parsing.
+*)
+module Antiquot = struct
+
+  let fmt_id = Printf.sprintf "(tyxml%i)"
+  let regex_id = Re.(seq [ str "(tyxml" ; rep digit ; char ')' ])
+  let re_id = Re.compile regex_id
+  let whole_re_id = Re.(compile @@ whole_string regex_id)
+
+  let make_id =
+    let r = ref 0 in
+    fun () -> incr r ; fmt_id !r
+
+  module H = Hashtbl.Make(struct
+      type t = string
+      let hash = Hashtbl.hash
+      let equal (x:string) y = x = y
+    end)
+
+  let tbl = H.create 17
+
+  let create expr =
+    let s = make_id () in
+    H.add tbl s expr ;
+    s
+
+  let get loc s =
+    if H.mem tbl s then H.find tbl s
+    else
+      Ppx_common.error loc
+        "Internal error: This expression placeholder is not registered."
+
+  let mem s = H.mem tbl s
+
+  let contains loc s = match Re.exec_opt re_id s with
+    | None -> `No
+    | Some g ->
+      let (i,j) = Re.Group.offset g 0 in
+      let is_whole = i = 0 && j = String.length s in
+      if is_whole
+      then `Whole (get loc s)
+      else `Yes (get loc @@ Re.Group.get g 0)
+
+  let assert_no_antiquot ~loc kind (_namespace,s) =
+    match contains loc s with
+    | `No -> ()
+    | `Yes e | `Whole e ->
+      Ppx_common.error e.pexp_loc
+        "OCaml expressions are not accepted as %s names." kind
+
+end
+
+(** Building block to rebuild the output with expressions intertwined. *)
+
+let make_pcdata ~loc s =
+  [%expr pcdata [%e Ppx_common.string loc s]][@metaloc loc]
+
+(** Walk the text list to replace placeholders by OCaml expressions when
+    appropriate. Use {!make_pcdata} on the rest. *)
+let make_text ~loc ss =
+  let buf = Buffer.create 17 in
+  let push_pcdata buf l =
+    let s = Buffer.contents buf in
+    Buffer.clear buf ;
+    if s = "" then l else make_pcdata ~loc s :: l
+  in
+  let rec aux ~loc res = function
+    | [] -> push_pcdata buf res
+    | `Text s :: t ->
+        Buffer.add_string buf s ;
+        aux ~loc res t
+    | `Delim g :: t ->
+      let e = Antiquot.get loc @@ Re.get g 0 in
+      aux ~loc (e :: push_pcdata buf res) t
+  in
+  aux ~loc [] @@ Re.split_full Antiquot.re_id @@ String.concat "" ss
+
+let replace_attribute ~loc (attr,value) =
+  Antiquot.assert_no_antiquot ~loc "attribute" attr ;
+  match Antiquot.contains loc value with
+  | `No -> (attr, `String value)
+  | `Whole e -> (attr, `Expr e)
+  | `Yes _ ->
+      Ppx_common.error loc
+      "Mixing literals and OCaml expressions is not authorized in attribute values."
 
 (* Converts a Markup.ml input location into an OCaml location. [start_loc] is
    the OCaml location of the string being parsed by Markup.ml.
@@ -61,19 +148,10 @@ let adjust_location start_loc delimiter_length consumed (line, column) =
    [markup_to_expr] first converts the payload to a list of strings and TyXML
    expressions. It then builds an input stream for Markup.ml, which walks this
    list. Bytes in strings encountered are passed to Markup.ml. When a TyXML
-   expression is encountered, it is appended to the current child list.
-
-   The current child list is a piece of state maintained by the assembler, which
-   reads the Markup.ml signal (output) stream and recursively assembles the
-   TyXML expression.
-
-   The current implementation stores the child list in a reference, because it
-   is modified by both the assembler and the input stream function. A better
-   implementation would scan the payload for the locations of literal TyXML
-   expressions, and merge them into the child list in the assembler. *)
+   expression is encountered, a dummy token is inserted that is later replaced by
+   the proper expression. *)
 let markup_to_expr loc expr =
   let current_adjust_location = ref (adjust_location Location.none 0 0) in
-  let current_children = ref [] in
 
   let input_stream =
     let expressions =
@@ -83,28 +161,28 @@ let markup_to_expr loc expr =
     in
 
     let strings_and_antiquotations =
-      expressions |> List.map (fun expr ->
-        match expr.pexp_desc with
-        (* TODO: Doesn't work in 4.03, can't pattern match. *)
-        | Pexp_constant (Const_string (s, maybe_delimiter)) ->
-          let delimiter_length =
-            match maybe_delimiter with
-            | None -> 1
-            | Some d -> String.length d + 2
-          in
-          `String (s, expr.pexp_loc, delimiter_length)
+      expressions |> List.map @@ fun expr ->
+      match expr.pexp_desc with
+      (* TODO: Doesn't work in 4.03, can't pattern match. *)
+      | Pexp_constant (Const_string (s, maybe_delimiter)) ->
+        let delimiter_length =
+          match maybe_delimiter with
+          | None -> 1
+          | Some d -> String.length d + 2
+        in
+        (s, expr.pexp_loc, delimiter_length)
 
-        | _ ->
-          `Expression expr)
+      | _ ->
+        (Antiquot.create expr, expr.pexp_loc, 0)
     in
 
     let items = ref strings_and_antiquotations in
     let offset = ref 0 in
     let consumed = ref 0 in
 
-    let rec next () =
-      match !items with
-      | (`String (s, loc, delimiter_length))::rest ->
+    let rec next () = match !items with
+      | [] -> None
+      | (s, loc, delimiter_length)::rest ->
         if !offset = 0 then begin
           current_adjust_location :=
             adjust_location loc delimiter_length !consumed;
@@ -120,14 +198,6 @@ let markup_to_expr loc expr =
           items := rest;
           next ()
         end
-
-      | (`Expression expr)::rest ->
-        current_children := expr::!current_children;
-        items := rest;
-        next ()
-
-      | [] ->
-        None
     in
 
     Markup.fn next
@@ -150,39 +220,33 @@ let markup_to_expr loc expr =
   in
   let signals = Markup.signals parser in
 
-  let rec assemble () =
-    match Markup.next signals with
-    | None | Some `End_element ->
-      current_children := List.rev !current_children
-
-    | Some (`Text ss) ->
-      let loc = parser |> Markup.location |> !current_adjust_location in
-      let node =
-        [%expr pcdata [%e Ppx_common.string loc (String.concat "" ss)]]
-          [@metaloc loc]
-      in
-      current_children := node::!current_children;
-      assemble ()
-
-    | Some (`Start_element (name, attributes)) ->
-      let loc = parser |> Markup.location |> !current_adjust_location in
-
-      let accumulator = !current_children in
-      current_children := [];
-      assemble ();
-      let children = !current_children in
-
-      let node = Ppx_element.parse ~loc ~name ~attributes children in
-
-      current_children := node::accumulator;
-      assemble ()
-
-    | Some _ ->
-      assemble ()
+  let get_loc () =
+    parser |> Markup.location |> !current_adjust_location
   in
 
-  assemble ();
-  Ppx_common.list loc !current_children
+  let rec assemble children =
+    match Markup.next signals with
+    | None | Some `End_element -> List.rev children
+
+    | Some (`Text ss) ->
+      let loc = get_loc () in
+      let node = make_text ~loc ss in
+      assemble (node @ children)
+
+    | Some (`Start_element (name, attributes)) ->
+      let loc = get_loc () in
+
+      let sub_children = assemble [] in
+      Antiquot.assert_no_antiquot ~loc "element" name ;
+      let attributes = List.map (replace_attribute ~loc) attributes in
+      let node = Ppx_element.parse ~loc ~name ~attributes sub_children in
+      assemble (node :: children)
+
+    | Some _ ->
+      assemble children
+  in
+
+  Ppx_common.list loc @@ assemble []
 
 
 

--- a/test/main_test.ml
+++ b/test/main_test.ml
@@ -2,4 +2,5 @@
 
 let () = Alcotest.run "tyxml" (
   Test_html.tests
+  @ Test_ppx.tests
 )

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -1,0 +1,84 @@
+(** Ppx Tests
+
+    This file is here to torture the ppx. Tests that are directly related to
+    html or svg should go to the other files.
+*)
+
+open Html5
+
+module TyTests = struct
+  type t = Xml.elt list
+  let pp fmt x =
+    P.print_list ~output:(Format.pp_print_string fmt) (M.totl x)
+  let equal = (=)
+end
+
+
+let tyxml_tests l =
+  let f (name, ty1, ty2) =
+    name, `Quick, fun () ->
+      Alcotest.(check (module TyTests)) name (M.toeltl ty1) (M.toeltl ty2)
+  in
+  List.map f l
+
+module Html5 = M
+let basics = "ppx basics", tyxml_tests M.[
+
+  "elems",
+  [%tyxml "<p></p>"],
+  [p []] ;
+
+  "child",
+  [%tyxml "<p><span>foo</span></p>"],
+  [p [span [pcdata "foo"]]] ;
+
+  "list",
+  [%tyxml "<p></p><span>foo</span>"],
+  [p [] ; span [pcdata "foo"]] ;
+
+  "attrib",
+  [%tyxml "<p id=foo></p>"],
+  [p ~a:[a_id "foo"] []] ;
+
+  "attribs",
+  [%tyxml "<p id=foo class=bar></p>"],
+  [p ~a:[a_id "foo"; a_class ["bar"] ] []] ;
+
+]
+
+let elt1 = M.(span [pcdata "one"])
+let elt2 = M.(b [pcdata "two"])
+let id = "pata"
+
+let antiquot = "ppx antiquot", tyxml_tests M.[
+
+  "child",
+  [%tyxml "<p>" elt1 "</p>"],
+  [p [elt1]];
+
+  "children",
+  [%tyxml "<p>bar"elt1"foo"elt2"baz</p>"],
+  [p [pcdata "bar"; elt1 ; pcdata "foo" ; elt2 ; pcdata "baz" ]];
+
+  "insertion",
+  [%tyxml "<p><em>" elt1 "</em></p>"],
+  [p [em [elt1]]];
+
+  "attrib",
+  [%tyxml "<p id="id">bla</p>"],
+  [p ~a:[a_id id] [pcdata "bla"]];
+
+  (* should succeed *)
+  (* "escape", *)
+  (* [%tyxml "<p>(tyxml4)</p>"], *)
+  (* [p [pcdata "(tyxml4)"]]; *)
+
+
+]
+
+
+
+let tests = [
+  basics ;
+  antiquot ;
+]

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -44,6 +44,10 @@ let basics = "ppx basics", tyxml_tests M.[
   [%tyxml "<p id=foo class=bar></p>"],
   [p ~a:[a_id "foo"; a_class ["bar"] ] []] ;
 
+  "comment",
+  [%tyxml "<!--foo-->"],
+  [tot @@ Xml.comment "foo"]
+
 ]
 
 let elt1 = M.(span [pcdata "one"])

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -4,12 +4,12 @@
     html or svg should go to the other files.
 *)
 
-open Html5
-
 module TyTests = struct
   type t = Xml.elt list
   let pp fmt x =
-    P.print_list ~output:(Format.pp_print_string fmt) (M.totl x)
+    Format.pp_print_list ~pp_sep:(fun _ () -> ())
+      (Html5.pp_elt ())
+      fmt (Html5.totl x)
   let equal = (=)
 end
 
@@ -17,12 +17,11 @@ end
 let tyxml_tests l =
   let f (name, ty1, ty2) =
     name, `Quick, fun () ->
-      Alcotest.(check (module TyTests)) name (M.toeltl ty1) (M.toeltl ty2)
+      Alcotest.(check (module TyTests)) name (Html5.toeltl ty1) (Html5.toeltl ty2)
   in
   List.map f l
 
-module Html5 = M
-let basics = "ppx basics", tyxml_tests M.[
+let basics = "ppx basics", tyxml_tests Html5.[
 
   "elems",
   [%tyxml "<p></p>"],
@@ -50,11 +49,11 @@ let basics = "ppx basics", tyxml_tests M.[
 
 ]
 
-let elt1 = M.(span [pcdata "one"])
-let elt2 = M.(b [pcdata "two"])
+let elt1 = Html5.(span [pcdata "one"])
+let elt2 = Html5.(b [pcdata "two"])
 let id = "pata"
 
-let antiquot = "ppx antiquot", tyxml_tests M.[
+let antiquot = "ppx antiquot", tyxml_tests Html5.[
 
   "child",
   [%tyxml "<p>" elt1 "</p>"],


### PR DESCRIPTION
This is a preliminary (but working) implementation of a PPX rewriter for TyXML, based on the HTML5 parser in [Markup.ml][markup]. Here are usage examples, paired with the dumped TyXML expressions that are generated:

[markup]: https://github.com/aantron/markup.ml

#### Basic

```ocaml
let Html5 = Html5.M
let _ = [%tyxml "<img src='foo' alt='bar' id='baz'>"]
```

```ocaml
let _ =
  [Html5.img ~src:(Html5.Xml.W.return "foo") ~alt:(Html5.Xml.W.return "bar")
     ~a:[Html5.a_id (Html5.Xml.W.return "baz")] ()]
```

#### Antiquotation

```ocaml
let Html5 = Html5.M
let _ = [%tyxml "<p>foo<em>bar</em></p><p>" (pcdata "bar") "</p>"]
```

```ocaml
let _ =
  [Html5.p
     (Html5.Xml.W.cons (Html5.pcdata "foo")
        (Html5.Xml.W.cons
           (Html5.em
              (Html5.Xml.W.cons (Html5.pcdata "bar") (Html5.Xml.W.nil ())))
           (Html5.Xml.W.nil ())));
  Html5.p (Html5.Xml.W.cons (Html5.pcdata "bar") (Html5.Xml.W.nil ()))]
```

#### SVG

```ocaml
let Html5 = Html5.M
let Svg = Svg.M
let _ = [%tyxml "<p><svg><g id='foo'/></svg></p>"]
```

```ocaml
let _ =
  [Html5.p
     (Html5.Xml.W.cons
        (Html5.svg
           (Svg.Xml.W.cons
              (Svg.g ~a:[Svg.a_id (Svg.Xml.W.return "foo")]
                 (Svg.Xml.W.nil ())) (Svg.Xml.W.nil ())))
        (Html5.Xml.W.nil ()))]
```

Errors have location information, although without https://github.com/aantron/markup.ml/issues/6, these are points instead of ranges, and, for errors inside a tag, the location reported is the start of the tag:

```ocaml
let _ = [%tyxml "<ul><ul></ul></ul>"]
```
```
File "test.ml", line 1, characters 18-18:
Error: This expression has type
         ([> Html5_types.ul ] as 'a) Html5.elt Html5.Xml.W.tlist =
           'a Html5.elt list
       but an expression was expected of type
         ([< Html5_types.ul_content_fun ] as 'b) Html5.elt Html5.list_wrap =
           'b Html5.elt list
       Type 'a Html5.elt = 'a Html5.M.elt is not compatible with type
         'b Html5.elt = 'b Html5.M.elt 
       Type 'a = [> `Ul ] is not compatible with type
         'b = [< `Li of Html5_types.li_attrib ] 
       The second variant type does not allow tag(s) `Ul
```

This would resolve #68. I will amend the commit to say "Closes #68" before this is merged into master, when review is done.

This makes TyXML depend on Markup.ml. However, projects using TyXML would not pull in Markup.ml as a run-time dependency, because it is used only in TyXML's PPX.

### How it works and reading order

The PPX itself does a pretty straightforward translation of a Markup.ml signal stream into a TyXML expression tree. However, since different TyXML elements and attributes have different signatures, some type information is needed for the PPX to be able to assemble the TyXML tree correctly. This type information is generated by a second PPX rewriter called `ppx_reflect`, which is a build tool that runs on `html5_sigs.mli`, `svg_sigs.mli`, and `html5_types.mli`.

For a bottom-up review, you can look at the files in order: `ppx_common.mli`, `ppx_attribute_value.mli`, `ppx_element_content.mli`, `ppx_sigs_reflected.mli`, `ppx_reflect.ml`, `ppx_namespace.mli`, `ppx_attribute.mli`, `ppx_element.mli`, `ppx_tyxml.ml`.

### Notes

- There is an ambiguity in interpeting newlines: was the newline inserted by the user using `\n`, or by creating a new line in the file? This affects how source location information is reported. I chose to always assume the latter, because it seems that people would want to have a multiline template more than inserting pointless `\n` escapes into markup meant for TyXML trees – unless, perhaps, they are creating `<pre>` elements.

### Issues

*(Edited to reflect status)*

- [ ] Support for date format in `<input>` `min`, `max`. Is there a good library for parsing this?
- [ ] User-facing documentation. Considering saving this for another PR.
- [ ] Make strict parsing optional.
- [ ] Support for namespaced attributes like `xmlns`, `xml:space`, etc.
- [ ] Proper OASIS packaging: a Findlib package which provides an executable but no library. For now, I created a library package that has no visible modules.
- [ ] Don't assume Ocaml ≥ 4.02. Did the OASIS flag eliminate this concern?
- [x] Generalize antiquotations. They are currently only supported as the entire content of an element. It should be possible to fix this after dealing with https://github.com/aantron/markup.ml/issues/6. That should allow antiquotations in attributes and interspersed in content. We should probably leave this for a future PR.
- [x] Switch to re completely.
- [ ] Break up `Ppx_attributes.parse` and `Ppx_tyxml.markup_expr`.
- [x] Change strategy for merging antiquotations with parser output (explained
in a comment in the code).
- [x] Consider changing the quotation name.
- [x] Consider allowing specification of the module name used for qualifying combinators. I assumed that the HTML5 module in scope will be called `Html5`, and similarly there will be a module `Svg`. This is in line with what `pa_tyxml` expects. However, these obviously shadow the real `Html5` and `Svg`.
- [ ] Deal with string delimiter representation in 4.03.
- [ ] Ensure 4.03 compatibility.
- [x] Fix labeled argument filter (see comments below).
- [ ] Module-qualify top-level calls to `pcdata` and other combinators.
- [x] Whether the quotation is HTML or SVG is determined automatically from the elements inside, but this does not work for `a`, because there are `a` elements in both HTML and SVG. Deal with this.
- [ ] Document clearly how locations are adjusted before being reported to users in errors.
- [x] Annotate `a_fs_rows` and `a_fs_cols`.

Also, as we have agreed, the PPX would benefit from having a test suite (as would the rest of TyXML).