### PR TITLE
Various improvements to the ppx:

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -225,6 +225,20 @@ Test mini_website
   TestTools: mini_website
   Run$: flag(tests)
 
+Executable mini_website_ppx
+  Install: false
+  Build$: flag(tests) && flag(tests)
+  Path: examples/mini_website_ppx
+  MainIs: minihtml.ml
+  BuildDepends: tyxml
+  CompiledObject: best
+
+Test mini_website_ppx
+  WorkingDirectory: examples/mini_website_ppx
+  Command: $mini_website
+  TestTools: mini_website
+  Run$: flag(tests) && flag(tests)
+
 ## Documentation
 
 Document "tyxml-api"

--- a/_tags
+++ b/_tags
@@ -14,3 +14,5 @@ true: keep_locs
 
 # Tests use the tyxml ppx
 <test/*.ml>: ppx_tyxml
+
+<examples/mini_website_ppx/*.ml>: ppx_tyxml

--- a/examples/mini_website_ppx/.merlin
+++ b/examples/mini_website_ppx/.merlin
@@ -1,0 +1,1 @@
+PKG tyxml.ppx

--- a/examples/mini_website_ppx/Makefile
+++ b/examples/mini_website_ppx/Makefile
@@ -1,0 +1,8 @@
+site_gen := minihtml
+
+all:
+	ocamlfind ocamlc minihtml.ml -short-paths -package tyxml.ppx -linkpkg -o ${site_gen}
+	./${site_gen}
+
+clean:
+	rm -f *.cmo *.cmt *.cmi ${site_gen} index.html

--- a/examples/mini_website_ppx/Readme.md
+++ b/examples/mini_website_ppx/Readme.md
@@ -1,0 +1,12 @@
+This is the minimal website in pure tyxml using the ppx syntax extension.
+To generate the website, compile `minihtml.ml` and then execute. This can be done with `make`.
+
+Content of this directory:
+- `minihtml.ml`: Generates the Html.
+- `Makefile`: Simple rules to create the website.
+- `.merlin`: An appropriate merlin file.
+- Readme.md : You are reading it
+
+This website is distributed under the [unlicense][], feel free to use it!
+
+[unlicense]: http://unlicense.org/

--- a/examples/mini_website_ppx/minihtml.ml
+++ b/examples/mini_website_ppx/minihtml.ml
@@ -1,0 +1,19 @@
+
+let mycontent = [%html5 {|
+  <div class="content">
+    <h1>A fabulous title</h1>
+    This is a fabulous content.
+  </div>
+|}]
+
+
+let mytitle = Html5.pcdata "A Fabulous Web Page"
+
+let mypage = [%html5
+  "<html><head><title>"mytitle"</title></head><body>"mycontent"</body></html>"]
+
+let () =
+  let file = open_out "index.html" in
+  let fmt = Format.formatter_of_out_channel file in
+  Html5.pp () fmt mypage;
+  close_out file

--- a/implem/html5.mli
+++ b/implem/html5.mli
@@ -25,6 +25,7 @@
     See {!modtype:Html5_sigs.T}.
 *)
 include Html5_sigs.Make(Xml)(Svg).T
+  with module Xml.W = Xml_wrap.NoWrap
 
 (** {2 Printers} *)
 

--- a/implem/svg.mli
+++ b/implem/svg.mli
@@ -25,6 +25,7 @@
     See {!modtype:Svg_sigs.T}.
 *)
 include Svg_sigs.Make(Xml).T
+  with module Xml.W = Xml_wrap.NoWrap
 
 (** {2 Printers} *)
 

--- a/ppx/ppx_attribute_value.ml
+++ b/ppx/ppx_attribute_value.ml
@@ -19,26 +19,22 @@
 
 open Asttypes
 open Ast_helper
-
-type value = [
-  | `String of string
-  | `Expr of Parsetree.expression
-]
+module Pc = Ppx_common
 
 type 'a gparser =
   ?separated_by:string -> ?default:string -> Location.t -> string -> 'a ->
     Parsetree.expression option
 
 type parser = string gparser
-type vparser = value gparser
+type vparser = string Pc.value gparser
 
 (* Handle expr *)
 
 let expr (parser : parser) : vparser =
   fun ?separated_by ?default loc name v ->
     match v with
-    | `Expr e -> Some e
-    | `String s -> parser ?separated_by ?default loc name s
+    | Antiquot e -> Some e
+    | Val s -> parser ?separated_by ?default loc name s
 
 (* Options. *)
 

--- a/ppx/ppx_attribute_value.mli
+++ b/ppx/ppx_attribute_value.mli
@@ -20,19 +20,11 @@
 (** Attribute value parsers and parser combinators. *)
 
 
-type value = [
-  | `String of string
-  | `Expr of Parsetree.expression
-]
-(** Values are either an OCaml expression, provided through an antiquotations
-    or a string parser from a literal.
-*)
-
 type 'a gparser =
   ?separated_by:string -> ?default:string -> Location.t -> string -> 'a ->
-  Parsetree.expression option
-and parser = string gparser
-and vparser = value gparser
+    Parsetree.expression option
+type parser = string gparser
+type vparser = string Ppx_common.value gparser
 (** Attribute value parsers are assigned to each attribute depending on the type
     of the attribute's argument, though some attributes have special parsers
     based on their name, or on a [[@@reflect]] annotation. A parser is a

--- a/ppx/ppx_attributes.mli
+++ b/ppx/ppx_attributes.mli
@@ -22,7 +22,7 @@
 
 
 val parse :
-  Location.t -> Markup.name -> (Markup.name * Ppx_attribute_value.value) list ->
+  Location.t -> Markup.name -> (Markup.name * string Ppx_common.value) list ->
     (Asttypes.label * Parsetree.expression) list
 (** [parse loc element_name attributes] evaluates to a list of labeled parse
     trees, each representing an attribute argument to the element function for

--- a/ppx/ppx_common.mli
+++ b/ppx/ppx_common.mli
@@ -46,5 +46,19 @@ val wrap :
 (** [wrap_exp implementation loc e] creates a parse tree for
     [implementation.Xml.W.return e]. *)
 
+type 'a value =
+  | Val of 'a
+  | Antiquot of Parsetree.expression
+
+val map_value : ('a -> 'b) -> 'a value -> 'b value
+val value : 'a -> 'a value
+val antiquot : Parsetree.expression -> _ value
+
+val wrap_value :
+  lang -> Location.t -> Parsetree.expression value -> Parsetree.expression
+val list_wrap_value :
+  lang -> Location.t -> Parsetree.expression value list -> Parsetree.expression
+
+
 val error : Location.t -> ('b, unit, string, 'a) format4 -> 'b
 (** Raises an error using compiler module [Location]. *)

--- a/ppx/ppx_common.mli
+++ b/ppx/ppx_common.mli
@@ -30,6 +30,8 @@ val lang : lang -> string
 val implementation : lang -> string
 val set_implementation : lang -> string -> unit
 
+val make_lid :
+  loc:Location.t -> lang -> string -> Longident.t Location.loc
 val make :
   loc:Location.t -> lang -> string -> Parsetree.expression
 

--- a/ppx/ppx_element.ml
+++ b/ppx/ppx_element.ml
@@ -17,10 +17,20 @@
  * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02111-1307, USA.
 *)
 
-let parse ~loc ~name:((ns, name) as element_name) ~attributes children =
+let parse
+    ~loc ~parent_lang
+    ~name:((ns, name) as element_name) ~attributes children =
 
   let attributes = Ppx_attributes.parse loc element_name attributes in
   let lang, (module Reflected) = Ppx_namespace.reflect loc ns in
+
+  let lang = match parent_lang, lang with
+    | Ppx_common.Html, Svg -> Ppx_common.Html
+    | Html, Html | Svg, Svg -> lang
+    | Svg, Html ->
+      Ppx_common.error loc
+        "Nesting of Html element inside svg element is not authorized."
+  in
 
   let name =
     try List.assoc name Reflected.renamed_elements

--- a/ppx/ppx_element.mli
+++ b/ppx/ppx_element.mli
@@ -21,13 +21,16 @@
 
 val parse :
   loc:Location.t ->
+  parent_lang:Ppx_common.lang ->
   name:Markup.name ->
   attributes:(Markup.name * Ppx_attribute_value.value) list ->
   Parsetree.expression Ppx_common.value list ->
   Parsetree.expression
-(** [parse ~loc ~name ~attributes children] evaluates to a parse tree for applying
-    the TyXML function corresponding to element [name] to suitable arguments
-    representing [attributes] and [children]. *)
+(** [parse ~loc ~parent_lang ~name ~attributes children]
+    evaluates to a parse tree for applying the TyXML function corresponding
+    to element [name] to suitable arguments representing [attributes] and
+    [children].
+*)
 
 val comment :
   loc:Location.t ->

--- a/ppx/ppx_element.mli
+++ b/ppx/ppx_element.mli
@@ -23,7 +23,7 @@ val parse :
   loc:Location.t ->
   parent_lang:Ppx_common.lang ->
   name:Markup.name ->
-  attributes:(Markup.name * Ppx_attribute_value.value) list ->
+  attributes:(Markup.name * string Ppx_common.value) list ->
   Parsetree.expression Ppx_common.value list ->
   Parsetree.expression
 (** [parse ~loc ~parent_lang ~name ~attributes children]

--- a/ppx/ppx_element.mli
+++ b/ppx/ppx_element.mli
@@ -23,7 +23,7 @@ val parse :
   loc:Location.t ->
   name:Markup.name ->
   attributes:(Markup.name * Ppx_attribute_value.value) list ->
-  Parsetree.expression list ->
+  Parsetree.expression Ppx_common.value list ->
   Parsetree.expression
 (** [parse ~loc ~name ~attributes children] evaluates to a parse tree for applying
     the TyXML function corresponding to element [name] to suitable arguments

--- a/ppx/ppx_element_content.ml
+++ b/ppx/ppx_element_content.ml
@@ -25,52 +25,19 @@ type assembler =
   lang:Ppx_common.lang ->
   loc:Location.t ->
   name:string ->
-  Parsetree.expression list ->
+  Parsetree.expression Ppx_common.value list ->
   (Pc.Label.t * Parsetree.expression) list
 
 
 
 (* Helpers. *)
 
-(* Called on a parse tree representing a child of an element. The argument
-   [implementation] is the module name (string) ["Html5"] if the parent element
-   is in the HTML namespace, and ["Svg"] if the parent is in the SVG namespace.
-
-   - If the child is an unqualified application of the function [pcdata],
-     qualifies it with the module [implementation].
-   - If [implementation] is ["Html5"] and the child is an application of [svg]
-     from any module, modifies the child to be an application of [Html5.svg]
-   - Otherwise, evaluates to the child as passed. *)
-let qualify_child lang = function
-  | [%expr pcdata [%e? s]] as e ->
-    let identifier =
-      Pc.make ~loc:e.pexp_loc lang "pcdata"
-    in
-    [%expr [%e identifier] [%e s]] [@metaloc e.pexp_loc]
-
-  | {pexp_desc =
-      Pexp_apply ({pexp_desc = Pexp_ident lid}, arguments)} as e
-      when Longident.last lid.txt = "svg" && lang = Html ->
-    let identifier = Pc.make ~loc:lid.loc Html "svg" in
-    {e with pexp_desc = Pexp_apply (identifier, arguments)}
-
-  | e -> e
-
-(* Called on a list of parse trees representing children of an element. The
-   argument [implementation] is as in [qualify_child]. Applies [qualify_child]
-   to each child, then assembles the children into a parse tree representing a
-   value of type [_ implementation.list_wrap]. *)
-let list_wrap_exp lang loc es =
-  es
-  |> List.map (qualify_child lang)
-  |> Pc.list_wrap lang loc
-
 (* Given a list of parse trees representing children of an element, filters out
    all children that consist of applications of [pcdata] to strings containing
    only whitespace. *)
 let filter_whitespace children =
   children |> List.filter (function
-    | [%expr pcdata [%e? s]]-> begin
+    | Pc.Val [%expr pcdata [%e? s]]-> begin
         match Ast_convenience.get_str s with
         | Some s when String.trim s = "" -> false
         | _ -> true
@@ -80,7 +47,7 @@ let filter_whitespace children =
 (* Given a parse tree and a string [name], checks whether the parse tree is an
    application of a function with name [name]. *)
 let is_element_with_name name = function
-  | {pexp_desc = Pexp_apply ({pexp_desc = Pexp_ident {txt}}, _)}
+  | Pc.Val {pexp_desc = Pexp_apply ({pexp_desc = Pexp_ident {txt}}, _)}
       when txt = name -> true
   | _ -> false
 
@@ -105,15 +72,12 @@ let nullary ~lang:_ ~loc ~name children =
 let unary ~lang ~loc ~name children =
   match children with
   | [child] ->
-    let child =
-      qualify_child lang child
-      |> Pc.wrap lang loc
-    in
+    let child = Pc.wrap_value lang loc child in
     [Pc.Label.nolabel, child]
   | _ -> Pc.error loc "%s should have exactly one child" name
 
 let star ~lang ~loc ~name:_ children =
-  [Pc.Label.nolabel, list_wrap_exp lang loc children]
+  [Pc.Label.nolabel, Pc.list_wrap_value lang loc children]
 
 
 
@@ -126,8 +90,8 @@ let html ~lang ~loc ~name children =
 
   match head, body, others with
   | [head], [body], [] ->
-    [Pc.Label.nolabel, Pc.wrap lang loc head;
-     Pc.Label.nolabel, Pc.wrap lang loc body]
+    [Pc.Label.nolabel, Pc.wrap_value lang loc head;
+     Pc.Label.nolabel, Pc.wrap_value lang loc body]
   | _ ->
     Pc.error loc
       "%s element must have exactly head and body child elements" name
@@ -137,7 +101,7 @@ let head ~lang ~loc ~name children =
 
   match title with
   | [title] ->
-    (Pc.Label.nolabel, Pc.wrap lang loc title) :: star ~lang ~loc ~name others
+    (Pc.Label.nolabel, Pc.wrap_value lang loc title) :: star ~lang ~loc ~name others
   | _ ->
     Pc.error loc
       "%s element must have exactly one title child element" name
@@ -148,7 +112,7 @@ let figure ~lang ~loc ~name children =
   | first::others ->
     if is_element_with_name (html5 "figcaption") first then
       ("figcaption",
-       [%expr `Top [%e Pc.wrap lang loc first]])::
+       [%expr `Top [%e Pc.wrap_value lang loc first]])::
           (star ~lang ~loc ~name others)
     else
       let children_reversed = List.rev children in
@@ -156,7 +120,7 @@ let figure ~lang ~loc ~name children =
       if is_element_with_name (html5 "figcaption") last then
         let others = List.rev (List.tl children_reversed) in
         ("figcaption",
-         [%expr `Bottom [%e Pc.wrap lang loc last]])::
+         [%expr `Bottom [%e Pc.wrap_value lang loc last]])::
             (star ~lang ~loc ~name others)
       else
         star ~lang ~loc ~name children
@@ -166,7 +130,7 @@ let object_ ~lang ~loc ~name children =
   let params, others = partition (html5 "param") children in
 
   if params <> [] then
-    ("params", list_wrap_exp lang loc params) :: star ~lang ~loc ~name others
+    ("params", Pc.list_wrap_value lang loc params) :: star ~lang ~loc ~name others
   else
     star ~lang ~loc ~name others
 
@@ -174,7 +138,7 @@ let audio_video ~lang ~loc ~name children =
   let sources, others = partition (html5 "source") children in
 
   if sources <> [] then
-    ("srcs", list_wrap_exp lang loc sources) :: star ~lang ~loc ~name others
+    ("srcs", Pc.list_wrap_value lang loc sources) :: star ~lang ~loc ~name others
   else
     star ~lang ~loc ~name others
 
@@ -186,13 +150,13 @@ let table ~lang ~loc ~name children =
 
   let one label = function
     | [] -> []
-    | [child] -> [label, Pc.wrap lang loc child]
+    | [child] -> [label, Pc.wrap_value lang loc child]
     | _ -> Pc.error loc "%s cannot have more than one %s" name label
   in
 
   let columns =
     if columns = [] then []
-    else ["columns", list_wrap_exp lang loc columns]
+    else ["columns", Pc.list_wrap_value lang loc columns]
   in
 
   (one "caption" caption) @
@@ -207,7 +171,7 @@ let fieldset ~lang ~loc ~name children =
   match legend with
   | [] -> star ~lang ~loc ~name others
   | [legend] ->
-    ("legend", Pc.wrap lang loc legend)::
+    ("legend", Pc.wrap_value lang loc legend)::
       (star ~lang ~loc ~name others)
   | _ -> Pc.error loc "%s cannot have more than one legend" name
 
@@ -218,11 +182,11 @@ let datalist ~lang ~loc ~name children =
     begin match others with
     | [] ->
       "children",
-      [%expr `Options [%e list_wrap_exp lang loc options]]
+      [%expr `Options [%e Pc.list_wrap_value lang loc options]]
 
     | _ ->
       "children",
-      [%expr `Phras [%e list_wrap_exp lang loc children]]
+      [%expr `Phras [%e Pc.list_wrap_value lang loc children]]
     end [@metaloc loc]
   in
 
@@ -233,14 +197,14 @@ let details ~lang ~loc ~name children =
 
   match summary with
   | [summary] ->
-    (Pc.Label.nolabel, Pc.wrap lang loc summary)::
+    (Pc.Label.nolabel, Pc.wrap_value lang loc summary)::
       (star ~lang ~loc ~name others)
   | _ -> Pc.error loc "%s must have exactly one summary child" name
 
 let menu ~lang ~loc ~name children =
   let children =
     "child",
-    [%expr `Flows [%e list_wrap_exp lang loc children]]
+    [%expr `Flows [%e Pc.list_wrap_value lang loc children]]
       [@metaloc loc]
   in
   children::(nullary ~lang ~loc ~name [])

--- a/ppx/ppx_element_content.mli
+++ b/ppx/ppx_element_content.mli
@@ -24,7 +24,7 @@ type assembler =
   lang:Ppx_common.lang ->
   loc:Location.t ->
   name:string ->
-  Parsetree.expression list ->
+  Parsetree.expression Ppx_common.value list ->
   (Ppx_common.Label.t * Parsetree.expression) list
 (** Assemblers satisfy: [assembler ~lang ~loc ~name children] evaluates
     to a list of optionally-labeled parse trees for passing [children] to the

--- a/ppx/ppx_tyxml.ml
+++ b/ppx/ppx_tyxml.ml
@@ -258,13 +258,16 @@ let markup_to_expr lang loc expr =
       assemble lang (node @ children)
 
     | Some (`Start_element (name, attributes)) ->
-      let lang = Ppx_namespace.to_lang loc @@ fst name in
+      let newlang = Ppx_namespace.to_lang loc @@ fst name in
       let loc = get_loc () in
 
-      let sub_children = assemble lang [] in
+      let sub_children = assemble newlang [] in
       Antiquot.assert_no_antiquot ~loc "element" name ;
       let attributes = List.map (replace_attribute ~loc) attributes in
-      let node = Ppx_element.parse ~loc ~name ~attributes sub_children in
+      let node =
+        Ppx_element.parse
+          ~parent_lang:lang ~loc ~name ~attributes sub_children
+      in
       assemble lang (Ppx_common.Val node :: children)
 
     | Some (`Comment s) ->

--- a/ppx/ppx_tyxml.ml
+++ b/ppx/ppx_tyxml.ml
@@ -260,7 +260,7 @@ let markup_to_expr ?context loc expr =
 let context_of_lang = function
   | None -> None
   | Some Ppx_common.Svg -> Some (`Fragment "svg")
-  | Some Html -> Some (`Fragment "html")
+  | Some Html -> None
 
 let markup_to_expr_with_implementation lang modname loc expr =
   let context = context_of_lang lang in
@@ -298,11 +298,6 @@ let dispatch_ext {txt ; loc} =
   | "svg" :: l
   | "tyxml" :: "svg" :: l ->
     Some (Some Ppx_common.Svg, get_modname ~loc l)
-  | "tyxml" :: []
-    -> Some (None, None)
-  | "tyxml" :: (_ :: _) ->
-    Ppx_common.error loc
-      "Module names are only accepted for html5 and svg quotations."
   | _ -> None
 
 open Ast_mapper

--- a/ppx/ppx_tyxml.ml
+++ b/ppx/ppx_tyxml.ml
@@ -274,7 +274,9 @@ let markup_to_expr lang loc expr =
       assemble lang children
   in
 
-  Ppx_common.list_wrap_value lang loc @@ assemble lang []
+  match assemble lang [] with
+  | [ Val x | Antiquot x ] -> x
+  | l -> Ppx_common.list_wrap_value lang loc l
 
 let markup_to_expr_with_implementation lang modname loc expr =
   match modname with

--- a/ppx/ppx_tyxml.ml
+++ b/ppx/ppx_tyxml.ml
@@ -229,15 +229,8 @@ let markup_to_expr lang loc expr =
 
   let input_stream, adjust_location = ast_to_stream expr in
 
-  (* The encoding is specified as a workaround: when not specified, Markup.ml
-     prescans the input looking for byte-order marks or <meta> tags. We don't
-     want a prescan, because that will trigger premature insertion of literal
-     TyXML expressions into the initial, empty, child list, by the input stream,
-     before the expression assembler starts running. This is fragile and will be
-     fixed by merging TyXML expressions in the assembler instead of as now. *)
   let parser =
     Markup.parse_html
-      ~encoding:Markup.Encoding.utf_8
       ?context
       ~report:(fun loc error ->
         let loc = adjust_location loc in

--- a/ppx/ppx_tyxml.ml
+++ b/ppx/ppx_tyxml.ml
@@ -156,8 +156,8 @@ let make_text ~loc ~lang ss =
 let replace_attribute ~loc (attr,value) =
   Antiquot.assert_no_antiquot ~loc "attribute" attr ;
   match Antiquot.contains loc value with
-  | `No -> (attr, `String value)
-  | `Whole e -> (attr, `Expr e)
+  | `No -> (attr, Ppx_common.value value)
+  | `Whole e -> (attr, Ppx_common.antiquot e)
   | `Yes _ ->
       Ppx_common.error loc
       "Mixing literals and OCaml expressions is not authorized in attribute values."

--- a/ppx/ppx_tyxml.ml
+++ b/ppx/ppx_tyxml.ml
@@ -40,18 +40,26 @@ module Loc = struct
     in
     shift loc.Location.loc_start delimiter_length
 
+  (** 0-width locations do not show in the toplevel. We expand them to
+      one-width.
+  *)
+  let one_width ?(ghost=false) pos =
+    { Location.loc_ghost = ghost ;
+      loc_start = pos ;
+      loc_end = shift pos 1
+    }
+
   (** Converts a Markup.ml input location into an OCaml location. [loc] is the
       start of the OCaml location of the string being parsed by Markup.ml.
       [consumed] is the number of bytes consumed by Markup.ml before the
       beginning of the current string.
       [(line, column)] is the Markup.ml location to be converted. *)
   let adjust loc consumed (line, column) =
-    let open Location in
     let open Lexing in
 
     let column =
-      if line <> 1 then column
-      else loc.pos_cnum - loc.pos_bol + column - consumed
+      if line <> 1 then column - 1
+      else loc.pos_cnum - loc.pos_bol + column - 1 - consumed
     in
     let line = loc.pos_lnum + line - 1 in
 
@@ -62,9 +70,7 @@ module Loc = struct
        pos_cnum  = column};
     in
 
-    {loc_start = position;
-     loc_end = position;
-     loc_ghost = false}
+    one_width position
 
 end
 

--- a/ppx/ppx_tyxml.mli
+++ b/ppx/ppx_tyxml.mli
@@ -20,7 +20,7 @@
 (** Internal functions to build tyxml's ppx. *)
 
 val markup_to_expr :
-  ?context:[ `Document | `Fragment of string ] ->
+  Ppx_common.lang ->
   Location.t -> Parsetree.expression -> Parsetree.expression
 (** Given the payload of a [%html5 ...] or [%svg ...] expression,
     converts it to a TyXML expression representing the markup

--- a/test/.merlin
+++ b/test/.merlin
@@ -1,2 +1,3 @@
 PKG alcotest
+FLG -ppx ../_build/ppx/ppx_tyxml_ex.native
 REC

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -51,6 +51,27 @@ let basics = "ppx basics", tyxml_tests Html5.[
   [[%html5 "foo"]],
   [pcdata "foo"] ;
 
+
+]
+
+let ns_nesting = "namespace nesting" , tyxml_tests Html5.[
+
+  "html/svg",
+  [[%html5 "<svg><g></g></svg>"]],
+  [svg [Svg.g []]] ;
+
+  "nested svg",
+  [[%html5 "<div><svg><g></g></svg></div>"]],
+  [div [svg [Svg.g []]]] ;
+
+  "with_neighbour",
+  [[%html5 "<div><span></span><svg><g></g></svg>foo</div>"]],
+  [div [span [] ; svg [Svg.g []] ; pcdata "foo" ]] ;
+
+  "ambiguous tag",
+  [[%html5 "<svg><a></a></svg>"]],
+  [svg [Svg.a []]] ;
+
 ]
 
 let elt1 = Html5.(span [pcdata "one"])
@@ -91,5 +112,6 @@ let antiquot = "ppx antiquot", tyxml_tests Html5.[
 
 let tests = [
   basics ;
+  ns_nesting ;
   antiquot ;
 ]

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -54,21 +54,25 @@ let basics = "ppx basics", tyxml_tests Html5.[
 ]
 
 let elt1 = Html5.(span [pcdata "one"])
-let elt2 = Html5.(b [pcdata "two"])
+let elt2 = Html5.[b [pcdata "two"]]
 let id = "pata"
 
 let antiquot = "ppx antiquot", tyxml_tests Html5.[
 
   "child",
-  [%html5 "<p>" elt1 "</p>"],
+  [%html5 "<p>" [elt1] "</p>"],
   [p [elt1]];
 
+  "list child",
+  [%html5 "<p>" elt2 "</p>"],
+  [p elt2];
+
   "children",
-  [%html5 "<p>bar"elt1"foo"elt2"baz</p>"],
-  [p [pcdata "bar"; elt1 ; pcdata "foo" ; elt2 ; pcdata "baz" ]];
+  [%html5 "<p>bar"[elt1]"foo"elt2"baz</p>"],
+  [p ([pcdata "bar"; elt1 ; pcdata "foo" ] @ elt2 @ [pcdata "baz" ])];
 
   "insertion",
-  [%html5 "<p><em>" elt1 "</em></p>"],
+  [%html5 "<p><em>"[elt1]"</em></p>"],
   [p [em [elt1]]];
 
   "attrib",

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -24,11 +24,11 @@ let tyxml_tests l =
 let basics = "ppx basics", tyxml_tests Html5.[
 
   "elems",
-  [%html5 "<p></p>"],
+  [[%html5 "<p></p>"]],
   [p []] ;
 
   "child",
-  [%html5 "<p><span>foo</span></p>"],
+  [[%html5 "<p><span>foo</span></p>"]],
   [p [span [pcdata "foo"]]] ;
 
   "list",
@@ -36,19 +36,19 @@ let basics = "ppx basics", tyxml_tests Html5.[
   [p [] ; span [pcdata "foo"]] ;
 
   "attrib",
-  [%html5 "<p id=foo></p>"],
+  [[%html5 "<p id=foo></p>"]],
   [p ~a:[a_id "foo"] []] ;
 
   "attribs",
-  [%html5 "<p id=foo class=bar></p>"],
+  [[%html5 "<p id=foo class=bar></p>"]],
   [p ~a:[a_id "foo"; a_class ["bar"] ] []] ;
 
   "comment",
-  [%html5 "<!--foo-->"],
+  [[%html5 "<!--foo-->"]],
   [tot @@ Xml.comment "foo"] ;
 
   "pcdata",
-  [%html5 "foo"],
+  [[%html5 "foo"]],
   [pcdata "foo"] ;
 
 ]
@@ -60,23 +60,23 @@ let id = "pata"
 let antiquot = "ppx antiquot", tyxml_tests Html5.[
 
   "child",
-  [%html5 "<p>" [elt1] "</p>"],
+  [[%html5 "<p>" [elt1] "</p>"]],
   [p [elt1]];
 
   "list child",
-  [%html5 "<p>" elt2 "</p>"],
+  [[%html5 "<p>" elt2 "</p>"]],
   [p elt2];
 
   "children",
-  [%html5 "<p>bar"[elt1]"foo"elt2"baz</p>"],
+  [[%html5 "<p>bar"[elt1]"foo"elt2"baz</p>"]],
   [p ([pcdata "bar"; elt1 ; pcdata "foo" ] @ elt2 @ [pcdata "baz" ])];
 
   "insertion",
-  [%html5 "<p><em>"[elt1]"</em></p>"],
+  [[%html5 "<p><em>"[elt1]"</em></p>"]],
   [p [em [elt1]]];
 
   "attrib",
-  [%html5 "<p id="id">bla</p>"],
+  [[%html5 "<p id="id">bla</p>"]],
   [p ~a:[a_id id] [pcdata "bla"]];
 
   (* should succeed *)

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -24,27 +24,27 @@ let tyxml_tests l =
 let basics = "ppx basics", tyxml_tests Html5.[
 
   "elems",
-  [%tyxml "<p></p>"],
+  [%html5 "<p></p>"],
   [p []] ;
 
   "child",
-  [%tyxml "<p><span>foo</span></p>"],
+  [%html5 "<p><span>foo</span></p>"],
   [p [span [pcdata "foo"]]] ;
 
   "list",
-  [%tyxml "<p></p><span>foo</span>"],
+  [%html5 "<p></p><span>foo</span>"],
   [p [] ; span [pcdata "foo"]] ;
 
   "attrib",
-  [%tyxml "<p id=foo></p>"],
+  [%html5 "<p id=foo></p>"],
   [p ~a:[a_id "foo"] []] ;
 
   "attribs",
-  [%tyxml "<p id=foo class=bar></p>"],
+  [%html5 "<p id=foo class=bar></p>"],
   [p ~a:[a_id "foo"; a_class ["bar"] ] []] ;
 
   "comment",
-  [%tyxml "<!--foo-->"],
+  [%html5 "<!--foo-->"],
   [tot @@ Xml.comment "foo"]
 
 ]
@@ -56,19 +56,19 @@ let id = "pata"
 let antiquot = "ppx antiquot", tyxml_tests Html5.[
 
   "child",
-  [%tyxml "<p>" elt1 "</p>"],
+  [%html5 "<p>" elt1 "</p>"],
   [p [elt1]];
 
   "children",
-  [%tyxml "<p>bar"elt1"foo"elt2"baz</p>"],
+  [%html5 "<p>bar"elt1"foo"elt2"baz</p>"],
   [p [pcdata "bar"; elt1 ; pcdata "foo" ; elt2 ; pcdata "baz" ]];
 
   "insertion",
-  [%tyxml "<p><em>" elt1 "</em></p>"],
+  [%html5 "<p><em>" elt1 "</em></p>"],
   [p [em [elt1]]];
 
   "attrib",
-  [%tyxml "<p id="id">bla</p>"],
+  [%html5 "<p id="id">bla</p>"],
   [p ~a:[a_id id] [pcdata "bla"]];
 
   (* should succeed *)

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -45,7 +45,11 @@ let basics = "ppx basics", tyxml_tests Html5.[
 
   "comment",
   [%html5 "<!--foo-->"],
-  [tot @@ Xml.comment "foo"]
+  [tot @@ Xml.comment "foo"] ;
+
+  "pcdata",
+  [%html5 "foo"],
+  [pcdata "foo"] ;
 
 ]
 


### PR DESCRIPTION
I removed the tyxml quotation. The namespace is now always provided by the quotation.

- Antiquotations inside lists (that is, star elements) now should be lists.
  Antiquotations inside unary elements can still be single elements
- The ppx will return a single element if there is only one element in the quotation.
- pcdata and svg-inside-html handling is probably a bit better now.
- Some judiciously placed type constraint allow better type errors for quotations.

@aantron: I think I broke `adjust_location` in one of my patches ...