### PR TITLE
Do not escape comments

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -64,7 +64,7 @@ Library tyxml_f
     Html5_sigs,
     Html5_types,
     Html5_f
-  BuildDepends: uutf
+  BuildDepends: uutf, re
 
 Library tyxml_top
   FindlibName: top

--- a/test/test_html.ml
+++ b/test/test_html.ml
@@ -53,6 +53,27 @@ let escaping = "html escaping", tyxml_tests Html5.[
 /* ]]> */
 |} ;
 
+  "comment",
+  tot (Xml.comment
+         {|[if IE 8]> <html class="no-js lt-ie9" lang="en"> <![endif]|}),
+  {|<!--[if IE 8]> <html class="no-js lt-ie9" lang="en"> <![endif]-->|} ;
+
+  "dodgy comment 1",
+  tot (Xml.comment {|><script BOUM/>|}),
+  {|<!--&gt;<script BOUM/>-->|} ;
+
+  "dodgy comment 2",
+  tot (Xml.comment {|-><script BOUM/>|}),
+  {|<!---&gt;<script BOUM/>-->|} ;
+
+  "dodgy comment 3",
+  tot (Xml.comment {|foo--><script BOUM/>|}),
+  {|<!--foo--&gt;<script BOUM/>-->|} ;
+
+  "dodgy comment 4",
+  tot (Xml.comment {|foo--!><script BOUM/>|}),
+  {|<!--foo--!&gt;<script BOUM/>-->|} ;
+
 ]
 
 


### PR DESCRIPTION
See https://github.com/ocsigen/tyxml/issues/90
This is only a simplistic fix (and it adds re as a dep of the functor part, which is annoying).