### PR TITLE
Makes the ppx archive non empty.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -129,6 +129,7 @@ Library ppx
   Install$: flag(ppx)
   FindlibName: ppx
   FindlibParent: tyxml
+  InternalModules: Ppx_tyxml_empty
   Path: ppx
   XMETADescription:
     HTML5 and SVG syntax extension (ppx)

--- a/ppx/ppx_tyxml_empty.ml
+++ b/ppx/ppx_tyxml_empty.ml
@@ -1,0 +1,1 @@
+(* Dummy ML file to workaround https://github.com/ocsigen/lwt/issues/91 *)


### PR DESCRIPTION
Workaround https://github.com/ocsigen/lwt/issues/91