### PR TITLE
Restore whitespace filtering in <html>.

### DIFF
--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -51,6 +51,14 @@ let basics = "ppx basics", tyxml_tests Html5.[
   [[%html5 "foo"]],
   [pcdata "foo"] ;
 
+  "document",
+  [[%html5 "<html><head><title>foo</title></head></html>"]],
+  [html (head (title (pcdata "foo")) []) (body [])] ;
+
+  "whitespace in html element",
+  [[%html5 "<html><head><title>foo</title></head> </html>"]],
+  [html (head (title (pcdata "foo")) []) (body [])] ;
+
 
 ]
 


### PR DESCRIPTION
Resolves #119.

In the original PR, `pcdata` calls were unqualified at the time whitespace was filtered in `<html>` elements. This has since changed. This commit changes the pattern to tolerate modules prefixed to `pcdata`.