### PR TITLE
Implement let%html constructs

### DIFF
--- a/doc/manual-wiki/ppx.wiki
+++ b/doc/manual-wiki/ppx.wiki
@@ -59,6 +59,20 @@ let my_div = [%html "<div id="my_id"></div>"]
 val my_div : [> Html_types.div ] Html.elt
 >>
 
+==@@id="let"@@ Let notation
+
+It is also possible to use the ppx with the ##let## notation:
+<<code language="ocaml"|
+let%html content = {|<div id="content">some content</div>|} ;;
+val content : [> Html_types.div ] Html.elt
+>>
+
+All the capabilities provided by the ppx are still available with this form. Additionally, the modifiers ##and## or ##rec## are available. It is also possible to create functions:
+<<code language="ocaml"|
+let%html make_content id = "<div id="id" >some content</div>" ;;
+val make_content : string -> [> Html_types.div ] Html.elt
+>>
+
 ==@@id="notes"@@ Notes
 
 === Locations ===

--- a/examples/mini_website_ppx/minihtml.ml
+++ b/examples/mini_website_ppx/minihtml.ml
@@ -1,23 +1,23 @@
 open Tyxml
 
-let mycontent = [%html {|
+let%html mycontent = {|
   <div class="content">
     <h1>A fabulous title</h1>
     This is a fabulous content.
   </div>
-|}]
+|}
 
 
 let mytitle = Html.pcdata "A Fabulous Web Page"
 
-let mypage = [%html
+let%html mypage =
   {|<html>
      <head>
        <title>|}mytitle{|</title>
      </head>
      <body>"mycontent"</body>
    </html>
-  |}]
+  |}
 
 let () =
   let file = open_out "index.html" in

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -22,15 +22,13 @@
 
 (* OASIS_START *)
 (* OASIS_STOP *)
+# 26 "myocamlbuild.ml"
 
 open Ocamlbuild_plugin
 
 (* Determine extension of CompiledObject: best *)
 let native_suffix =
-  let env =
-    BaseEnvLight.load ~allow_empty:true
-      ~filename:MyOCamlbuildBase.env_filename ()
-  in
+  let env = BaseEnvLight.load () in
   if BaseEnvLight.var_get "is_native" env = "true"
   then "native" else "byte"
 

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -57,6 +57,18 @@ let basics = "ppx basics", tyxml_tests Html.[
   [[%html "<html><head><title>foo</title></head></html>"]],
   [html (head (title (pcdata "foo")) []) (body [])] ;
 
+  "let",
+  [let%html x = "<p></p>" in x],
+  [p []] ;
+
+  "let and",
+  (let%html x = "<p></p>" and y = "<a></a>" in [x;y]),
+  [p []; a []] ;
+
+  "let fun",
+  [let%html f x = "<p>"x"</p>" in f [a []]],
+  [p [a []]] ;
+
   "whitespace in html element",
   [[%html "<html><head><title>foo</title></head> </html>"]],
   [html (head (title (pcdata "foo")) []) (body [])] ;


### PR DESCRIPTION
This works with functions and multiple bindings. In particular, something like that works:

```ocaml
let%html make_content content = {|
  <div class="content">|} content {|</div>
|}

let%html rec f = function
  | [] -> ""
  | h :: t -> "<li>" [h] "</li>" (f t)
val f :
  [< Html_types.li_content_fun ] Tyxml_html.elt list ->
  [> Html_types.li ] Tyxml_html.elt list
```

(And now that I've written out the second example, I'm not sure it's a great idea anymore :D)