### PR TITLE
Add "canonical" link type

### DIFF
--- a/lib/html_f.ml
+++ b/lib/html_f.ml
@@ -844,6 +844,7 @@ struct
     | `Archives -> "archives"
     | `Author -> "author"
     | `Bookmark -> "bookmark"
+    | `Canonical -> "canonical"
     | `External -> "external"
     | `First -> "first"
     | `Help -> "help"

--- a/lib/html_types.mli
+++ b/lib/html_types.mli
@@ -99,6 +99,7 @@ type linktype =
     | `Archives
     | `Author
     | `Bookmark
+    | `Canonical
     | `External
     | `First
     | `Help
@@ -139,6 +140,8 @@ type linktypes = linktype list
         Gives a link to the current document's author.}
         {- [`Bookmark]:
         Gives the permalink for the nearest ancestor section.}
+        {- [`Canonical]:
+        Gives the preferred location for accessing the current document.}
         {- [`External]:
         Indicates that the referenced document is not part of the same site as the current document.}
         {- [`First]:

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -125,6 +125,10 @@ let attribs = "ppx attribs", tyxml_tests Html.[
   [[%html "<form autocomplete=off></form>"]],
   [form ~a:[a_autocomplete false] []] ;
 
+  "link rel=canonical",
+  [[%html "<link rel=canonical href='/'>"]],
+  [link ~rel:[`Canonical] ~href:"/" ()] ;
+
 ]
 
 let ns_nesting = "namespace nesting" , tyxml_tests Html.[


### PR DESCRIPTION
This kind of `<link>` element is common in SEO work.