### PR TITLE
Fix capitalization in Html5_types.mediadesc_token

### DIFF
--- a/lib/html_f.ml
+++ b/lib/html_f.ml
@@ -875,8 +875,8 @@ struct
     | `Projection -> "projection"
     | `Screen -> "screen"
     | `Speech -> "speech"
-    | `TTY -> "tty"
-    | `TV -> "tv"
+    | `Tty -> "tty"
+    | `Tv -> "tv"
     | `Raw_mediadesc s -> s
 
   let string_of_big_variant = function

--- a/lib/html_types.mli
+++ b/lib/html_types.mli
@@ -187,8 +187,8 @@ type mediadesc_token =
   | `Projection
   | `Screen
   | `Speech
-  | `TTY
-  | `TV
+  | `Tty
+  | `Tv
   | `Raw_mediadesc of string ] [@@reflect.total_variant]
 
 type mediadesc = mediadesc_token list


### PR DESCRIPTION
Without this change, the PPX generates `` `Raw_mediadesc "tv"`` for `media=tv`, and similarly for `media=tty`.

Another way to solve this is to do a case-insensitive search for a matching variand. That slightly decreases the consistency of the API, but would allow intuitive labels `` `TV`` and `` `TTY`` to work "correctly" with the PPX. Let me know if you prefer that.