### PR TITLE
Remove "char" attribute

### DIFF
--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -585,6 +585,8 @@ module type T = sig
     [< | `None | `Groups | `Rows | `Cols | `All] wrap -> [> | `Rules] attrib
 
   val a_char : character wrap -> [> | `Char] attrib
+    [@@ocaml.deprecated "The char attribute is not supported in HTML5"]
+  (** @deprecated The char attribute is not supported in HTML5 *)
 
   val a_alt : text wrap -> [> | `Alt] attrib
 

--- a/ppx/ppx_attribute_value.mli
+++ b/ppx/ppx_attribute_value.mli
@@ -90,8 +90,9 @@ val nowrap : parser -> Ppx_common.lang -> vparser
 (** {2 Numeric} *)
 
 val char : parser
-(** [char _ _ s], where [s] is a string containing a single byte [c], produces
-    a parse tree for [c]. *)
+(** [char _ _ s], where [s] is a string containing a single UTF-8 character [c],
+    produces a parse tree for [c] of type [char]. Note that this means the range
+    is restricted to the first 256 code points. *)
 
 val bool : parser
 (** [bool _ _ s] produces a parse tree for the boolean [true]


### PR DESCRIPTION
This attribute is deprecated in HTML5, and was reportedly not well-supported by browsers before that.

It could be marked deprecated instead, but it seems the argument for removing it entirely is stronger than even for `cellspacing`/`cellpadding`.