### PR TITLE
Rename menu ?child to ?children

### DIFF
--- a/lib/html_f.ml
+++ b/lib/html_f.ml
@@ -671,12 +671,12 @@ struct
   let command ~label ?(a = []) () =
     Xml.leaf ~a: ((a_label label) :: a) "command"
 
-  let menu ?child ?a () =
-    let child = match child with
+  let menu ?children ?a () =
+    let children = match children with
       | None -> W.nil ()
       | Some (`Lis l)
       | Some (`Flows l) -> l in
-    Xml.node ?a "menu" child
+    Xml.node ?a "menu" children
 
   let embed = terminal "embed"
 

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -977,7 +977,7 @@ module type T = sig
     ], [> | `Command]) nullary
 
   val menu :
-    ?child:(
+    ?children:(
       [<
         | `Lis of ([< | `Li of [< | common]] elt) list_wrap
         | `Flows of ([< | flow5] elt) list_wrap


### PR DESCRIPTION
Admittedly a nit, but it bugged me that the child list was named `child`.