### PR TITLE
Remove form methods PUT and DELETE

### DIFF
--- a/lib/html_f.ml
+++ b/lib/html_f.ml
@@ -902,8 +902,6 @@ struct
     | `Rtl -> "rtl"
     | `Get -> "GET"
     | `Post -> "POST"
-    | `Put -> "PUT"
-    | `Delete -> "DELETE"
     | `Formnovalidate -> "formnovalidate"
     | `Hidden -> "hidden"
     | `Ismap -> "ismap"

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -479,10 +479,10 @@ module type T = sig
   val a_maxlength : number wrap -> [> | `Maxlength] attrib
 
   val a_method :
-    [< | `Get | `Post | `Put | `Delete] wrap -> [> | `Method] attrib
+    [< | `Get | `Post] wrap -> [> | `Method] attrib
 
   val a_formmethod :
-    [< | `Get | `Post | `Put | `Delete] wrap -> [> | `Method] attrib
+    [< | `Get | `Post] wrap -> [> | `Method] attrib
     [@@ocaml.deprecated "Use a_method"]
   (** @deprecated Use a_method *)
 

--- a/lib/html_types.mli
+++ b/lib/html_types.mli
@@ -2223,8 +2223,6 @@ type big_variant =
   | `Selected
   | `Get
   | `Post
-  | `Put
-  | `Delete
   | `Checked
   | `Disabled
   | `ReadOnly


### PR DESCRIPTION
Only `GET` and `POST` are officially supported.

W3C: https://www.w3.org/TR/html5/forms.html#attr-fs-method
WHATWG: https://html.spec.whatwg.org/multipage/forms.html#attr-fs-method

Perhaps there was some rationale for originally including `PUT` and `DELETE`?

The `dialog` value from the WHATWG version is for the `<dialog>` element, which is in HTML 5.1 right now, but it doesn't look well-supported at this point: http://caniuse.com/#feat=dialog. Do you want to include it?