### PR TITLE
Support date-time format in <input> min, max

### DIFF
--- a/lib/html_f.ml
+++ b/lib/html_f.ml
@@ -334,11 +334,11 @@ struct
 
   let a_max = float_attrib "max"
 
-  let a_input_max = float_attrib "max"
+  let a_input_max = user_attrib C.string_of_number_or_datetime "max"
 
   let a_min = float_attrib "min"
 
-  let a_input_min = float_attrib "min"
+  let a_input_min = user_attrib C.string_of_number_or_datetime "min"
 
   let a_inputmode x =
     user_attrib C.string_of_big_variant "inputmode" x
@@ -1005,6 +1005,10 @@ struct
     | `Time -> "time"
     | `Url -> "url"
     | `Week -> "week"
+
+  let string_of_number_or_datetime = function
+    | `Number n -> string_of_int n
+    | `Datetime t -> t
 
   let string_of_character = String.make 1
 

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -305,12 +305,12 @@ module type T = sig
 
   val a_max : float_number wrap -> [> | `Max] attrib
 
-  val a_input_max : float_number wrap -> [> | `Input_Max] attrib
+  val a_input_max : number_or_datetime wrap -> [> | `Input_Max] attrib
     [@@reflect.attribute "max" ["input"]]
 
   val a_min : float_number wrap -> [> | `Min] attrib
 
-  val a_input_min : float_number wrap -> [> | `Input_Min] attrib
+  val a_input_min : number_or_datetime wrap -> [> | `Input_Min] attrib
     [@@reflect.attribute "min" ["input"]]
 
   val a_inputmode :
@@ -1131,6 +1131,9 @@ module type Wrapped_functions = sig
 
   val string_of_input_type :
     ([< Html_types.input_type], string) Xml.W.ft
+
+  val string_of_number_or_datetime :
+    ([< Html_types.number_or_datetime], string) Xml.W.ft
 
   val string_of_linktypes :
     ([< Html_types.linktype] list, string) Xml.W.ft

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -304,13 +304,11 @@ module type T = sig
   val a_low : float_number wrap -> [> | `High] attrib
 
   val a_max : float_number wrap -> [> | `Max] attrib
-    [@@reflect.attribute "min" ["meter"; "progress"]]
 
   val a_input_max : float_number wrap -> [> | `Input_Max] attrib
     [@@reflect.attribute "max" ["input"]]
 
   val a_min : float_number wrap -> [> | `Min] attrib
-    [@@reflect.attribute "min" ["meter"]]
 
   val a_input_min : float_number wrap -> [> | `Input_Min] attrib
     [@@reflect.attribute "min" ["input"]]

--- a/lib/html_types.mli
+++ b/lib/html_types.mli
@@ -77,11 +77,19 @@ type contenttypes = contenttype list
 (** A comma-separated list of media types, as per RFC2045 (MIME).
         @see <http://tools.ietf.org/html/rfc2045> RFC2045 *)
 
+type number = int
+
+(* space-separated *)
+type numbers = number list
+
 type coords = string list
 (** Comma- separated list of coordinates to use in defining areas. *)
 
 type datetime = string
 (** Date and time information. *)
+
+type number_or_datetime = [ | `Number of number | `Datetime of datetime ]
+(** Either a number or date and time information. *)
 
 type fpi = string
 (** A character string representing an SGML Formal Public Identifier. *)
@@ -221,11 +229,6 @@ type mediadesc = mediadesc_token list
         For more complex (untyped) media descriptors.}}
 
 *)
-
-type number = int
-
-(* space-separated *)
-type numbers = number list
 
 type float_number = float
 

--- a/ppx/ppx_attribute_value.ml
+++ b/ppx/ppx_attribute_value.ml
@@ -534,6 +534,12 @@ let srcset_element =
 
     Some e
 
+let number_or_datetime ?separated_by:_ ?default:_ loc _ s =
+  match int_exp loc s with
+  | Some n -> Some [%expr `Number [%e n]]
+  | None -> Some [%expr `Datetime [%e Pc.string loc s]]
+  [@metaloc loc]
+
 
 
 (* Special-cased. *)

--- a/ppx/ppx_attribute_value.mli
+++ b/ppx/ppx_attribute_value.mli
@@ -196,6 +196,9 @@ val paint : parser
 val srcset_element : parser
 (** Used for [a_srcset]. *)
 
+val number_or_datetime : parser
+(** Used for [a_input_min] and [a_input_max]. *)
+
 
 
 (* {2 Special-cased}

--- a/ppx/ppx_reflect.ml
+++ b/ppx/ppx_reflect.ml
@@ -197,6 +197,9 @@ let rec to_attribute_parser lang name = function
   | [[%type: paint]] ->
     [%expr paint]
 
+  | [[%type: number_or_datetime]] ->
+    [%expr number_or_datetime]
+
   | [[%type: image_candidate list]] ->
     [%expr commas srcset_element]
 

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -167,6 +167,10 @@ let attribs = "ppx attribs", HtmlTests.make Html.[
   [[%html "<output for=foo></output>"]],
   [output_elt ~a:[a_output_for ["foo"]] []] ;
 
+  "input min time",
+  [[%html "<input min='2002-10-02T15:00:00Z'>"]],
+  [input ~a:[a_input_min (`Datetime "2002-10-02T15:00:00Z")] ()] ;
+
 ]
 
 let ns_nesting = "namespace nesting" , HtmlTests.make Html.[


### PR DESCRIPTION
I am representing dates as strings, as already done elsewhere in TyXML. We could also perhaps use https://github.com/sagotch/ISO8601.ml/ to validate them.

I am not sure about what I added to `Wrapped_functions`, please give it a good look :)