### PR TITLE
Require Markup.ml 0.7.2.

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -1,7 +1,5 @@
 export ALCOTEST_SHOW_ERRORS=true
 
-opam pin add --no-action markup https://github.com/aantron/markup.ml.git\#input-stream
-
 opam pin add --no-action tyxml .
 opam pin add --no-action tyxml_ppx .
 

--- a/tyxml_ppx.opam
+++ b/tyxml_ppx.opam
@@ -11,7 +11,7 @@ dev-repo: "https://github.com/ocsigen/tyxml.git"
 build: ["ocamlfind" "query" "tyxml.ppx"]
 depends: [
   "tyxml"
-  "markup"
+  "markup" {>= "0.7.2"}
   "ppx_tools"
 ]
 available: ocaml-version >= "4.02"


### PR DESCRIPTION
I also removed the Jenkins pin on the Markup.ml development branch, so this should be merged after https://github.com/ocaml/opam-repository/pull/6472 and the new `markup` is installable from OPAM. I'll bump this thread when that's so.