### PR TITLE
Flush error message formatter in the PPX.

### DIFF
--- a/ppx/ppx_common.ml
+++ b/ppx/ppx_common.ml
@@ -65,7 +65,9 @@ let error loc ppf =
   let buf = Buffer.create 17 in
   let fmt = Format.formatter_of_buffer buf in
   Format.kfprintf
-    (fun _ -> Location.raise_errorf ~loc "%s" (Buffer.contents buf))
+    (fun _ ->
+      Format.pp_print_flush fmt ();
+      Location.raise_errorf ~loc "%s" (Buffer.contents buf))
     fmt
     (error_prefix^^ppf)
 


### PR DESCRIPTION
Resolves #157. cc @eras

With this change, the output is (I reformatted the example slightly):

```
File "foo.ml", line 2, characters 20-21:
Error: head element must have exactly one title child element
```

The error itself may seem counterintuitive, but the spec says to silently insert `<head>` and `<body>` elements, then put `error` into the body. The PPX then requires `<head>` to have a title, but it doesn't. Perhaps we should address implicit elements in error message better in the future.