### PR TITLE
Support for Uutf 1.0.0.

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -9,5 +9,5 @@ FLG -w +A-4-9-40-42-44-48
 FLG -w -32-34-37
 FLG -strict_sequence -safe_string
 
-PKG uutf re
+PKG uchar uutf re
 PKG compiler-libs.common ppx_tools.metaquot markup

--- a/_oasis
+++ b/_oasis
@@ -56,7 +56,7 @@ Library tyxml_f
     Html_sigs,
     Html_types,
     Html_f
-  BuildDepends: uutf, re
+  BuildDepends: uchar, uutf, re
 
 Library tyxml_top
   FindlibName: top

--- a/tyxml.opam
+++ b/tyxml.opam
@@ -30,6 +30,7 @@ remove: ["ocamlfind" "remove" "tyxml"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "uchar"
   "uutf"
   "base-bytes"
   "re" {>= "1.5.0"}


### PR DESCRIPTION
Do not merge before Uutf 1.0.0 is released (will happen soon) otherwise you'll need a a pin on `uutf`. Adds a dependency on the `uchar` compatibility package to the project.