### PR TITLE
Add support for the `minlength` form attribute

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+* Add support for the `minlength` form attribute (contribution by Armaël Guéneau)
+  (See https://www.w3.org/TR/html5/forms.html#attr-input-minlength)
+
 ===== 4.1.0 ====
 
 * Uses uutf 1.0 (contribution by Daniel Bunzli)

--- a/lib/html_f.ml
+++ b/lib/html_f.ml
@@ -264,6 +264,8 @@ struct
 
   let a_maxlength = int_attrib "maxlength"
 
+  let a_minlength = int_attrib "minlength"
+
   let a_name = string_attrib "name"
 
   let a_autocomplete x =

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -476,6 +476,8 @@ module type T = sig
 
   val a_maxlength : number wrap -> [> | `Maxlength] attrib
 
+  val a_minlength : number wrap -> [> | `Minlength] attrib
+
   val a_method :
     [< | `Get | `Post] wrap -> [> | `Method] attrib
 

--- a/lib/html_types.mli
+++ b/lib/html_types.mli
@@ -1994,6 +1994,7 @@ type input_attrib =
     | `List
     | `Input_Max
     | `Maxlength
+    | `Minlength
     | `Input_Min
     | `Multiple
     | `Name
@@ -2019,6 +2020,7 @@ type textarea_attrib =
     | `Disabled
     | `Form
     | `Maxlength
+    | `Minlength
     | `Name
     | `Placeholder
     | `ReadOnly


### PR DESCRIPTION
See https://www.w3.org/TR/html5/forms.html#attr-input-minlength

Fixes #169