### PR TITLE
Add basic support for aria-* attributes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+* Add basic support for `aria-*` attributes (contribution by Armaël Guéneau)
+  (see https://www.w3.org/TR/wai-aria-1.1/#states_and_properties)
 * Add support for the `role` attribute (contribution by Armaël Guéneau)
   (see https://www.w3.org/TR/role-attribute/)
 * Add support for the `minlength` form attribute (contribution by Armaël Guéneau)

--- a/lib/html_f.ml
+++ b/lib/html_f.ml
@@ -472,7 +472,11 @@ struct
 
   let a_media = mediadesc_attrib "media"
 
+  (* ARIA *)
+
   let a_role = space_sep_attrib "role"
+
+  let a_aria name = space_sep_attrib ("aria-" ^ name)
 
   type 'a elt = Xml.elt
 

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -664,6 +664,13 @@ module type T = sig
       @see <https://www.w3.org/TR/wai-aria-1.1/#role_definitions> List of WAI-ARIA roles
   *)
 
+  val a_aria : string -> string list wrap -> [> | `Aria] attrib
+  (** Basic support for WAI-ARIA attributes: [a_aria "foo"] corresponds to an
+      "aria-foo" attribute.
+
+      @see <https://www.w3.org/TR/wai-aria-1.1/#state_prop_def> List of WAI-ARIA attributes
+  *)
+
   (** {2:elements Elements} *)
 
   val pcdata : string wrap -> [> | `PCDATA] elt

--- a/lib/html_types.mli
+++ b/lib/html_types.mli
@@ -344,6 +344,7 @@ type events =
 type aria =
   [
     | `Role
+    | `Aria
   ]
 
 (** Common attributes *)

--- a/ppx/ppx_reflect.ml
+++ b/ppx/ppx_reflect.ml
@@ -154,6 +154,7 @@ let rec to_attribute_parser lang name = function
   | [[%type: color]] -> [%expr string]
 
   | [[%type: nmtoken]; [%type: text wrap]] -> [%expr wrap string]
+  | [[%type: string]; [%type: string list wrap]] -> [%expr wrap (spaces string)]
 
   | [[%type: Xml.event_handler]]
   | [[%type: Xml.mouse_event_handler]]

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -179,6 +179,10 @@ let attribs = "ppx attribs", HtmlTests.make Html.[
   [[%html "<input min='2002-10-02T15:00:00Z'>"]],
   [input ~a:[a_input_min (`Datetime "2002-10-02T15:00:00Z")] ()] ;
 
+  "aria attributes",
+  [[%html "<div aria-hidden=true></div>"]],
+  [div ~a:[a_aria "hidden" ["true"]] []] ;
+
 ]
 
 let ns_nesting = "namespace nesting" , HtmlTests.make Html.[


### PR DESCRIPTION
See https://www.w3.org/TR/wai-aria-1.1/#states_and_properties

The specification indicates that many aria- attributes are only valid for
elements of a given "role" (as specified by the "role" attribute). Here, we do
not try to encode these invariants in tyxml types (it is considered not worth
the trouble). A single [a_aria] function is thus provided, with [a_aria "foo"]
corresponding to the "aria-foo" attribute.