### PR TITLE
Html sigs avoid variants

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+* Various fixes in the Html_sigs.T module (contribution by Fabian Pijcke):
+  * Fixed the map element function signature.
+  * The elements functions now (almost) all make use of the types defined in Html_types, rather than redefining them.
+  * Html_sigs.T.fieldset now takes [< legend] elt wrap as optional argument rather than legend elt wrap.
 * Add basic support for `aria-*` attributes (contribution by Armaël Guéneau)
   (see https://www.w3.org/TR/wai-aria-1.1/#states_and_properties)
 * Add support for the `role` attribute (contribution by Armaël Guéneau)

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -878,7 +878,7 @@ module type T = sig
       | `Mime_type
     ], [> | area]) nullary
 
-  val map : ([< | map_attrib], 'a, [> | `A of 'a]) star
+  val map : ([< | map_attrib], 'a, [> | 'a map]) star
 
   (** {3 Tables Data} *)
 

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -22,6 +22,8 @@
 (** Signature of typesafe constructors for HTML documents. *)
 module type T = sig
 
+  open Html_types
+
   (** HTML elements.
 
       Element constructors are in section {{!elements}elements}. Most elements constructors
@@ -119,8 +121,6 @@ module type T = sig
 
   (** Various information about HTML, such as the doctype, ... *)
   module Info : Xml_sigs.Info
-
-  open Html_types
 
   (** {3 Uri} *)
 
@@ -926,7 +926,7 @@ module type T = sig
   val form : ([< | form_attrib], [< | form_content_fun], [> | form]) star
 
   val fieldset :
-    ?legend: [ | `Legend ] elt wrap ->
+    ?legend: [< | legend ] elt wrap ->
     ([< | fieldset_attrib], [< | fieldset_content_fun], [> | fieldset]) star
   [@@reflect.element "fieldset"]
 

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -48,7 +48,7 @@ module type T = sig
   type +'a elt
 
   (** A complete HTML document. *)
-  type doc = [ `Html ] elt
+  type doc = html elt
 
   (** HTML attributes
 
@@ -673,16 +673,16 @@ module type T = sig
 
   (** {2:elements Elements} *)
 
-  val pcdata : string wrap -> [> | `PCDATA] elt
+  val pcdata : string wrap -> [> | pcdata] elt
 
   val html :
     ?a: ((html_attrib attrib) list) ->
-    [< | `Head] elt wrap -> [< | `Body] elt wrap -> [> | `Html] elt
+    [< | head] elt wrap -> [< | body] elt wrap -> [> | html] elt
   [@@reflect.element "html"]
 
   val head :
     ?a: ((head_attrib attrib) list) ->
-    [< | `Title] elt wrap -> (head_content_fun elt) list_wrap -> [> | head] elt
+    [< | title] elt wrap -> (head_content_fun elt) list_wrap -> [> | head] elt
   [@@reflect.element "head"]
 
   val base : ([< | base_attrib], [> | base]) nullary
@@ -764,7 +764,7 @@ module type T = sig
     ([< | figcaption_attrib], [< | figcaption_content_fun], [> | figcaption]) star
 
   val figure :
-    ?figcaption: ([`Top of [< `Figcaption ] elt wrap | `Bottom of [< `Figcaption ] elt wrap ]) ->
+    ?figcaption: ([`Top of [< | figcaption ] elt wrap | `Bottom of [< | figcaption ] elt wrap ]) ->
     ([< | figure_attrib], [< | figure_content_fun], [> | figure]) star
   [@@reflect.element "figure"]
 
@@ -840,7 +840,7 @@ module type T = sig
     ([< | iframe_attrib], [< | iframe_content_fun], [> | iframe]) star
 
   val object_ :
-    ?params: (([< | `Param] elt) list_wrap ) ->
+    ?params: (([< | param] elt) list_wrap ) ->
     ([< | object__attrib], 'a, [> | `Object of 'a]) star
   [@@reflect.element "object_" "object"]
 
@@ -952,7 +952,7 @@ module type T = sig
   val datalist :
     ?children:(
       [<
-        | `Options of ([< | `Option] elt) list_wrap
+        | `Options of ([< | selectoption] elt) list_wrap
         | `Phras of ([< | phrasing] elt) list_wrap
       ]) ->
     ([< | datalist_attrib], [> | datalist]) nullary
@@ -987,19 +987,19 @@ module type T = sig
       @see <http://www.w3schools.com/html/html_entities.asp> A tutorial on HTML entities.
       @see <https://www.w3.org/TR/html5/syntax.html#named-character-references> The list of HTML entities.
   *)
-  val entity : string -> [> | `PCDATA] elt
+  val entity : string -> [> | pcdata] elt
 
-  val space : unit -> [> | `PCDATA] elt
+  val space : unit -> [> | pcdata] elt
 
-  val cdata : string -> [> | `PCDATA] elt
-  val cdata_script : string -> [> | `PCDATA] elt
-  val cdata_style : string -> [> | `PCDATA] elt
+  val cdata : string -> [> | pcdata] elt
+  val cdata_script : string -> [> | pcdata] elt
+  val cdata_style : string -> [> | pcdata] elt
 
 
   (** {3 Interactive} *)
 
   val details :
-    [< | `Summary] elt wrap ->
+    [< | summary] elt wrap ->
     ([< | details_attrib], [< | details_content_fun], [> | details]) star
   [@@reflect.element "details"]
 

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -697,10 +697,10 @@ module type T = sig
   (** {3 Section} *)
 
   val footer :
-    ([< | common], [< | flow5_without_header_footer], [> | `Footer]) star
+    ([< | footer_attrib], [< | footer_content_fun], [> | footer]) star
 
   val header :
-    ([< | common], [< | flow5_without_header_footer], [> | `Header]) star
+    ([< | header_attrib], [< | header_content_fun], [> | header]) star
 
   val section :
     ([< | section_attrib], [< | section_content_fun], [> | section]) star
@@ -791,7 +791,7 @@ module type T = sig
 
   val bdo :
     dir: [< | `Ltr | `Rtl] wrap ->
-    ([< | common], [< | phrasing], [> | `Bdo]) star
+    ([< | bdo_attrib], [< | bdo_content_fun], [> | bdo]) star
 
   val abbr : ([< | abbr_attrib], [< | abbr_content_fun], [> | abbr]) star
 
@@ -822,12 +822,12 @@ module type T = sig
 
   (** {3 Hypertext} *)
 
-  val a : ([< | a_attrib], 'a, [> | `A of 'a]) star
+  val a : ([< | a_attrib], 'a, [> | 'a a]) star
 
   (** {3 Edit} *)
 
-  val del : ([< | del_attrib], 'a, [> | `Del of 'a]) star
-  val ins : ([< | ins_attrib], 'a, [> | `Ins of 'a]) star
+  val del : ([< | del_attrib], 'a, [> | 'a del]) star
+  val ins : ([< | ins_attrib], 'a, [> | 'a ins]) star
 
   (** {3 Embedded} *)
 
@@ -837,27 +837,16 @@ module type T = sig
     ([< img_attrib], [> img]) nullary
 
   val iframe :
-    ([< | common | `Src | `Name | `Sandbox | `Seamless | `Width | `Height],
-     [< | `PCDATA], [> | `Iframe]) star
+    ([< | iframe_attrib], [< | iframe_content_fun], [> | iframe]) star
 
   val object_ :
     ?params: (([< | `Param] elt) list_wrap ) ->
-    ([<
-      | common
-      | `Data
-      | `Form
-      | `Mime_type
-      | `Height
-      | `Width
-      | `Name
-      | `Usemap
-    ], 'a, [> | `Object of 'a ]) star
+    ([< | object__attrib], 'a, [> | `Object of 'a]) star
   [@@reflect.element "object_" "object"]
 
   val param : ([< | param_attrib], [> | param]) nullary
 
-  val embed :
-    ([< | common | `Src | `Height | `Mime_type | `Width], [> | `Embed]) nullary
+  val embed : ([< | embed_attrib], [> | embed]) nullary
 
   val audio :
     ?src:Xml.uri wrap ->
@@ -887,7 +876,7 @@ module type T = sig
       | `Media
       | `Hreflang
       | `Mime_type
-    ], [> | `Area]) nullary
+    ], [> | area]) nullary
 
   val map : ([< | map_attrib], 'a, [> | `A of 'a]) star
 
@@ -938,8 +927,7 @@ module type T = sig
 
   val fieldset :
     ?legend: [ | `Legend ] elt wrap ->
-    ([< | common | `Disabled | `Form | `Name], [< | flow5],
-     [> | `Fieldset]) star
+    ([< | fieldset_attrib], [< | fieldset_content_fun], [> | fieldset]) star
   [@@reflect.element "fieldset"]
 
   val legend :
@@ -966,12 +954,13 @@ module type T = sig
       [<
         | `Options of ([< | `Option] elt) list_wrap
         | `Phras of ([< | phrasing] elt) list_wrap
-      ]) -> ([< | common], [> | `Datalist]) nullary
+      ]) ->
+    ([< | datalist_attrib], [> | datalist]) nullary
   [@@reflect.element "datalist"]
 
   val optgroup :
     label: text wrap  ->
-    ([< | common | `Disabled | `Label], [< | `Option], [> | `Optgroup]) star
+    ([< | optgroup_attrib], [< | optgroup_content_fun], [> | optgroup]) star
 
   val option :
     ([< | option_attrib], [< | option_content_fun], [> | selectoption]) unary
@@ -1011,7 +1000,7 @@ module type T = sig
 
   val details :
     [< | `Summary] elt wrap ->
-    ([< | common | `Open], [< | flow5], [> | `Details]) star
+    ([< | details_attrib], [< | details_content_fun], [> | details]) star
   [@@reflect.element "details"]
 
   val summary :
@@ -1019,21 +1008,15 @@ module type T = sig
 
   val command :
     label: text wrap ->
-    ([<
-      | common
-      | `Icon
-      | `Disabled
-      | `Checked
-      | `Radiogroup
-      | `Command_Type
-    ], [> | `Command]) nullary
+    ([< | command_attrib], [> | command]) nullary
 
   val menu :
     ?children:(
       [<
         | `Lis of ([< | `Li of [< | common]] elt) list_wrap
         | `Flows of ([< | flow5] elt) list_wrap
-      ]) -> ([< | common | `Label | `Menu_Type], [> | `Menu]) nullary
+      ]) ->
+    ([< | menu_attrib], [> | menu]) nullary
   [@@reflect.element "menu"]
 
   (** {3 Scripting} *)
@@ -1054,15 +1037,7 @@ module type T = sig
   val link :
     rel: linktypes wrap ->
     href: Xml.uri wrap ->
-    ([<
-      | common
-      | `Hreflang
-      | `Media
-      | `Rel
-      | `Href
-      | `Sizes
-      | `Mime_type
-    ], [> | `Link]) nullary
+    ([< | link_attrib], [> | link]) nullary
 
   (** {3 Ruby} *)
 


### PR DESCRIPTION
This is the easy part of #182. All the types defined in Html_sigs.T that were exactly as defined in Html_types have been replaced by the corresponding type (defined in Html_types).

There remain two problems, that should be addressed in separate issues:

- The area element allows some Download attribute in Html_types, but not in Html_sigs.T;
- The object element allows some Object_interactive output in Html_types, but not in Html_sigs.T.

Hence, this closes #182.