### PR TITLE
Simplistic indentation for the Format-based printer.

### DIFF
--- a/examples/basic_website/site_html.ml
+++ b/examples/basic_website/site_html.ml
@@ -58,7 +58,7 @@ let emit_page (name, page) =
   Printf.printf "Generating: %s\n" name ;
   let file_handle = open_out name in
   let fmt = Format.formatter_of_out_channel file_handle in
-  pp () fmt page;
+  Format.fprintf fmt "%a@." (pp ()) page;
   close_out file_handle
 
 let () = List.iter emit_page pages

--- a/examples/basic_website/site_html.ml
+++ b/examples/basic_website/site_html.ml
@@ -58,7 +58,7 @@ let emit_page (name, page) =
   Printf.printf "Generating: %s\n" name ;
   let file_handle = open_out name in
   let fmt = Format.formatter_of_out_channel file_handle in
-  Format.fprintf fmt "%a@." (pp ()) page;
+  Format.fprintf fmt "%a@." (pp ~indent:true ()) page;
   close_out file_handle
 
 let () = List.iter emit_page pages

--- a/examples/basic_website_ppx/site_html.ml
+++ b/examples/basic_website_ppx/site_html.ml
@@ -63,7 +63,7 @@ let emit_page (name, page) =
   Printf.printf "Generating: %s\n" name ;
   let file_handle = open_out name in
   let fmt = Format.formatter_of_out_channel file_handle in
-  Html.pp () fmt page;
+  Format.fprintf fmt "%a@." (Html.pp ()) page;
   close_out file_handle
 
 let () = List.iter emit_page pages

--- a/examples/basic_website_ppx/site_html.ml
+++ b/examples/basic_website_ppx/site_html.ml
@@ -63,7 +63,7 @@ let emit_page (name, page) =
   Printf.printf "Generating: %s\n" name ;
   let file_handle = open_out name in
   let fmt = Format.formatter_of_out_channel file_handle in
-  Format.fprintf fmt "%a@." (Html.pp ()) page;
+  Format.fprintf fmt "%a@." (Html.pp ~indent:true ()) page;
   close_out file_handle
 
 let () = List.iter emit_page pages

--- a/examples/mini_website/minihtml.ml
+++ b/examples/mini_website/minihtml.ml
@@ -16,5 +16,5 @@ let mypage =
 let () =
   let file = open_out "index.html" in
   let fmt = Format.formatter_of_out_channel file in
-  pp () fmt mypage;
+  Format.fprintf fmt "%a@." (pp ()) mypage;
   close_out file

--- a/examples/mini_website/minihtml.ml
+++ b/examples/mini_website/minihtml.ml
@@ -16,5 +16,5 @@ let mypage =
 let () =
   let file = open_out "index.html" in
   let fmt = Format.formatter_of_out_channel file in
-  Format.fprintf fmt "%a@." (pp ()) mypage;
+  Format.fprintf fmt "%a@." (pp ~indent:true ()) mypage;
   close_out file

--- a/examples/mini_website_ppx/minihtml.ml
+++ b/examples/mini_website_ppx/minihtml.ml
@@ -22,5 +22,5 @@ let%html mypage =
 let () =
   let file = open_out "index.html" in
   let fmt = Format.formatter_of_out_channel file in
-  Html.pp () fmt mypage;
+  Format.fprintf fmt "%a@." (Html.pp ()) mypage;
   close_out file

--- a/examples/mini_website_ppx/minihtml.ml
+++ b/examples/mini_website_ppx/minihtml.ml
@@ -22,5 +22,5 @@ let%html mypage =
 let () =
   let file = open_out "index.html" in
   let fmt = Format.formatter_of_out_channel file in
-  Format.fprintf fmt "%a@." (Html.pp ()) mypage;
+  Format.fprintf fmt "%a@." (Html.pp ~indent:true ()) mypage;
   close_out file

--- a/implem/tyxml_html.mli
+++ b/implem/tyxml_html.mli
@@ -35,11 +35,13 @@ include Html_sigs.Make(Tyxml_xml)(Tyxml_svg).T
     {[let s = Format.asprintf "%a" (Tyxml.Html.pp ()) my_html]}
 *)
 val pp:
-  ?encode:(string -> string) -> ?advert:string -> unit -> Format.formatter -> doc -> unit
+  ?encode:(string -> string) -> ?indent:bool -> ?advert:string -> unit ->
+  Format.formatter -> doc -> unit
 
 (** [pp_elt ()] is a {!Format} printer for Html elements. *)
 val pp_elt :
-  ?encode:(string -> string) -> unit -> Format.formatter -> 'a elt -> unit
+  ?encode:(string -> string) -> ?indent:bool -> unit ->
+  Format.formatter -> 'a elt -> unit
 
 (** Parametrized stream printer for Html documents.
     @deprecated Use {!pp} instead.

--- a/implem/tyxml_svg.mli
+++ b/implem/tyxml_svg.mli
@@ -35,11 +35,13 @@ include Svg_sigs.Make(Tyxml_xml).T
     {[let s = Format.asprintf "%a" (Tyxml.Svg.pp ()) my_svg]}
 *)
 val pp:
-  ?encode:(string -> string) -> ?advert:string -> unit -> Format.formatter -> doc -> unit
+  ?encode:(string -> string) -> ?indent:bool -> ?advert:string -> unit ->
+  Format.formatter -> doc -> unit
 
 (** [pp_elt ()] is a {!Format} printer for Svg elements. *)
 val pp_elt :
-  ?encode:(string -> string) -> unit -> Format.formatter -> 'a elt -> unit
+  ?encode:(string -> string) -> ?indent:bool -> unit ->
+  Format.formatter -> 'a elt -> unit
 
 (** Parametrized stream printer for Svg documents.
     @deprecated Use {!pp} instead.

--- a/implem/tyxml_xml.mli
+++ b/implem/tyxml_xml.mli
@@ -27,8 +27,8 @@ include Xml_sigs.Iterable
    and type mouse_event_handler = string
    and type keyboard_event_handler = string
 
-
-val pp : ?encode:(string -> string) -> unit -> Format.formatter -> elt -> unit
+include Xml_sigs.Pp
+  with type elt := elt
 
 
 (** {2 Iterators} *)

--- a/lib/xml_sigs.mli
+++ b/lib/xml_sigs.mli
@@ -189,7 +189,8 @@ module type Pp = sig
     Various implementations of [encode] are available in {!Xml_print}.
 *)
   val pp:
-    ?encode:(string -> string) -> unit -> Format.formatter -> elt -> unit
+    ?encode:(string -> string) -> ?indent:bool -> unit ->
+    Format.formatter -> elt -> unit
 end
 
 module type Typed_pp = sig
@@ -203,7 +204,8 @@ module type Typed_pp = sig
     Various implementations of [encode] are available in {!Xml_print}.
 *)
   val pp_elt :
-    ?encode:(string -> string) -> unit -> Format.formatter -> 'a elt -> unit
+    ?encode:(string -> string) -> ?indent:bool -> unit ->
+    Format.formatter -> 'a elt -> unit
 
 (** [pp ()] is a {!Format} printer for complete documents.
 
@@ -214,6 +216,7 @@ module type Typed_pp = sig
     Various implementations of [encode] are available in {!Xml_print}.
 *)
   val pp:
-    ?encode:(string -> string) -> ?advert:string -> unit -> Format.formatter -> doc -> unit
+    ?encode:(string -> string) -> ?indent:bool -> ?advert:string -> unit ->
+    Format.formatter -> doc -> unit
 
 end

--- a/test/emitbig.ml
+++ b/test/emitbig.ml
@@ -18,7 +18,7 @@ let rec unfold n =
 let emit_page_pp page =
   let file_handle = open_out "fibo.html" in
   let fmt = Format.formatter_of_out_channel file_handle in
-  Html.pp () fmt page;
+  Format.fprintf fmt "%a@." (Html.pp ()) page;
   close_out file_handle
 
 let () =

--- a/test/emitbig.ml
+++ b/test/emitbig.ml
@@ -15,21 +15,22 @@ let rec unfold n =
   in
   Html.(div ~a:[a_class ["fibo" ^ string_of_int n]] l)
 
-let emit_page_pp page =
+let emit_page_pp indent page =
   let file_handle = open_out "fibo.html" in
   let fmt = Format.formatter_of_out_channel file_handle in
-  Format.fprintf fmt "%a@." (Html.pp ()) page;
+  Format.fprintf fmt "%a@." (Html.pp ~indent ()) page;
   close_out file_handle
 
 let () =
   let p = Html.(
     html (head (title (pcdata "fibo")) []) (body [unfold 22])
   ) in
+  let indent = Array.length Sys.argv > 1 && Sys.argv.(1) = "indent" in
   let time_pp = ref 0. in
   let n = 10 in
   for _ = 1 to n do
     let t = Unix.gettimeofday () in
-    emit_page_pp p ;
+    emit_page_pp indent p ;
     let tpp = Unix.gettimeofday () -. t in
     time_pp := !time_pp +. tpp ;
   done ;


### PR DESCRIPTION
The goal is not to have a great indentation engine, but something that is sufficient to be readable. There are many much more sophisticated pretty-printers for html out there. :)

Here is the output for the small website example:

```html
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml">
 <head><title>Your Cool Web Page</title>
  <link rel="stylesheet" href="home.css"/>
 </head>
 <body><div id="image_box"></div>
  <div id="content_box">
   <nav>
    <ul class="links_bar" id="links_bar"><li id="home_click">My Musings</li>
     <li id="about_click">About Me</li><li id="blog_posts_click">Blog</li>
     <li id="hackathons_click">Hackathons</li>
    </ul>
   </nav><div id="payload"><div><h2>Hello Coder</h2></div></div>
   <footer id="footer_box">
    <p>This site was made with <a href="http://ocaml.org">OCaml</a> and 
     <a href="https://www.gnu.org/software/emacs/">emacs</a>
    </p>
   </footer>
  </div><script src="main.js"></script>
 </body>
```

I haven't benchmarked yet.