### PR TITLE
Quick-and-dirty patch to compile with OCaml 4.06

### DIFF
--- a/ppx/ppx_reflect.ml
+++ b/ppx/ppx_reflect.ml
@@ -448,7 +448,8 @@ let emit_module () =
     ] else []
   end @
 
-  List.map Combi.(let_ AC.pvar (tuple2 str (list str))) !reflected_variants
+  List.map Combi.(let_ AC.pvar (tuple2 str (list str))) 
+		(List.map (fun (a, (b, c)) -> (a, (b.txt, List.map (fun x -> x.txt) c))) !reflected_variants)
 
 
 (* Crude I/O tools to read a signature and output a structure.


### PR DESCRIPTION
The ppx syntax extension doesn't compile with OCaml 4.06 (the expected type of reflected_variants in ppx/ppx_reflect.ml is string * (string * string list) rather than string * (string Location.loc * string Location.loc list)). Here is a quick patch to fix that - it can probably be implemented more efficiently when generating the content, but I didn't have the time to delve into the code that deeply.