### PR TITLE
Allow restricted flow content in dt elements

### DIFF
--- a/lib/html_types.mli
+++ b/lib/html_types.mli
@@ -1105,6 +1105,12 @@ type flow5_without_sectioning_heading_header_footer_address =
        flow5_without_media) transparent
   ]
 
+type flow5_without_sectioning_heading_header_footer =
+  [
+    | flow5_without_sectioning_heading_header_footer_address
+    | `Address
+  ]
+
 (*
   Type for HTML for elements
 *)
@@ -1392,9 +1398,9 @@ type dd_attrib = [ | common ]
 (* NAME: dt, KIND: star, TYPE: [= common ], [= phrasing], [=`Dt], ARG: [= phrasing], ATTRIB:  OUT: [=`Dt] *)
 type dt = [ | `Dt ]
 
-type dt_content = [ | phrasing ]
+type dt_content = [ | flow5_without_sectioning_heading_header_footer ]
 
-type dt_content_fun = [ | phrasing ]
+type dt_content_fun = [ | flow5_without_sectioning_heading_header_footer ]
 
 type dt_attrib = [ | common ]
 


### PR DESCRIPTION
From https://www.w3.org/TR/html5/grouping-content.html#the-dt-element:

> Content model:
Flow content, but with no header, footer, sectioning content, or heading content descendants.

By contrast, TyXML has:

https://github.com/ocsigen/tyxml/blob/820d3c6b3d795aec948314e026ec0c9484b54762/lib/html_types.mli#L1397

This isn't quite restrictive enough, because, e.g., a `div` could have a nested `h2`, but I am under the impression that is already an issue in TyXML.