### PR TITLE
Make the ppx work with wrapped APIs.

### DIFF
--- a/examples/mini_website_ppx/minihtml.ml
+++ b/examples/mini_website_ppx/minihtml.ml
@@ -15,7 +15,7 @@ let%html mypage =
      <head>
        <title>|}mytitle{|</title>
      </head>
-     <body>"mycontent"</body>
+     <body>|}[mycontent]{|</body>
    </html>
   |}
 

--- a/ppx/common.ml
+++ b/ppx/common.ml
@@ -106,17 +106,21 @@ let list loc l =
   list_gen cons append nil @@ List.map (fun x -> Val x) l
 
 let list_wrap_value lang loc =
+  let (!!) = make ~loc lang in
   let nil =
     [%expr
-      [%e make ~loc lang "Xml.W.nil"]
+      [%e !!"Xml.W.nil"]
       ()] [@metaloc loc]
   in
   let cons acc x =
-    [%expr [%e make ~loc lang "Xml.W.cons"] [%e x] [%e acc]][@metaloc loc]
+    [%expr [%e !!"Xml.W.cons"]
+        ([%e !!"Xml.W.return"] [%e x])
+        [%e acc]
+    ][@metaloc loc]
   in
   let append acc x =
     [%expr
-      [%e make ~loc lang "Xml.W.append"]
+      [%e !!"Xml.W.append"]
         [%e add_constraints ~list:true lang x] [%e acc]
     ][@metaloc loc]
   in
@@ -124,7 +128,6 @@ let list_wrap_value lang loc =
 
 let list_wrap lang loc l =
   list_wrap_value lang loc @@ List.map (fun x -> Val x) l
-
 
 let wrap implementation loc e =
   [%expr

--- a/ppx/common.mli
+++ b/ppx/common.mli
@@ -45,7 +45,7 @@ val list_wrap : lang -> Location.t -> Parsetree.expression list -> Parsetree.exp
 
 val wrap :
   lang -> Location.t -> Parsetree.expression -> Parsetree.expression
-(** [wrap_exp implementation loc e] creates a parse tree for
+(** [wrap implementation loc e] creates a parse tree for
     [implementation.Xml.W.return e]. *)
 
 type 'a value =

--- a/ppx/element_content.ml
+++ b/ppx/element_content.ml
@@ -34,9 +34,10 @@ type assembler =
 (* Given a parse tree [e], if [e] represents [_.pcdata s], where [s] is a string
    constant, evaluates to [Some s]. Otherwise, evaluates to [None]. *)
 let to_pcdata = function
-  | [%expr [%e? {pexp_desc = Pexp_ident f; _}] [%e? arg]] -> begin
-      match Longident.last f.txt, Ast_convenience.get_str arg with
-      | "pcdata", Some s -> Some s
+  | [%expr[%e? {pexp_desc = Pexp_ident f; _}]
+      ( [%e? {pexp_desc = Pexp_ident f2; _}] [%e? arg])] -> begin
+      match Longident.last f.txt, Longident.last f2.txt, Ast_convenience.get_str arg with
+      | "pcdata", "return", Some s -> Some s
       | _ -> None
     end
   | _ -> None

--- a/ppx/tyxml_ppx.ml
+++ b/ppx/tyxml_ppx.ml
@@ -195,8 +195,8 @@ end
 
 let make_pcdata ~loc ~lang s =
   let pcdata = Common.make ~loc lang "pcdata" in
-  Ast_helper.Exp.apply ~loc pcdata
-    [Common.Label.nolabel, Common.string loc s]
+  let arg = Common.wrap lang loc @@ Common.string loc s in
+  Ast_helper.Exp.apply ~loc pcdata [Common.Label.nolabel, arg]
 
 (** Walk the text list to replace placeholders by OCaml expressions when
     appropriate. Use {!make_pcdata} on the rest. *)

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -8,16 +8,23 @@ open Tyxml
 
 module type LANGUAGE = sig
   include Xml_sigs.Typed_pp
-  type 'a list_wrap = 'a Xml_wrap.NoWrap.tlist
+  type 'a wrap
+  type 'a list_wrap
+  val pp_wrap :
+    (Format.formatter -> 'a -> unit) ->
+    Format.formatter -> 'a wrap -> unit
+  val pp_wrap_list :
+    (Format.formatter -> 'a -> unit) ->
+    Format.formatter -> 'a list_wrap -> unit
   val totl : Xml.elt list_wrap -> ('a elt) list_wrap
   val toeltl : ('a elt) list_wrap -> Xml.elt list_wrap
 end
 
 module TyTests (Language : LANGUAGE) = struct
   module Testable = struct
-    type t = Xml.elt list
+    type t = Xml.elt Language.list_wrap
     let pp fmt x =
-      Format.pp_print_list ~pp_sep:(fun _ () -> ())
+      Language.pp_wrap_list
         (Language.pp_elt ())
         fmt (Language.totl x)
     let equal = (=)
@@ -32,8 +39,19 @@ module TyTests (Language : LANGUAGE) = struct
     List.map f l
 end
 
+module Html = struct
+  include Tyxml.Html
+  let pp_wrap pp = pp
+  let pp_wrap_list pp = Format.pp_print_list ~pp_sep:(fun _ () -> ()) pp
+end
+module Svg = struct
+  include Tyxml.Svg
+  let pp_wrap pp = pp
+  let pp_wrap_list pp = Format.pp_print_list ~pp_sep:(fun _ () -> ()) pp
+end
 module HtmlTests = TyTests (Html)
 module SvgTests = TyTests (Svg)
+
 
 let basics = "ppx basics", HtmlTests.make Html.[
 
@@ -337,7 +355,39 @@ let svg_element_names = "svg element names", SvgTests.make Svg.[
 
 ]
 
+(* The regular HTML module, but with most type equality hidden. 
+   This forces the use of the wrapping functions provided in Xml.W.
+*)
+module HtmlWrapped : sig
+  include Html_sigs.T
+    with type Xml.elt = Tyxml.Xml.elt
+     and type 'a elt = 'a Html.elt
+  include LANGUAGE
+    with type 'a elt := 'a elt
+     and type 'a wrap := 'a wrap
+     and type 'a list_wrap := 'a list_wrap
+     and type doc := doc
+end = struct
+  include Html
+  module Svg = Svg
+end
+module HtmlWrappedTests = TyTests(HtmlWrapped)
 
+let (@:) h t =  HtmlWrapped.Xml.W.(cons (return h) t)
+let (!) = HtmlWrapped.Xml.W.return
+let nil = HtmlWrapped.Xml.W.nil
+
+let wrapping =
+  let module Html = HtmlWrapped in
+  "wrapping", HtmlTests.make Html.[
+  "nil",
+  [[%html "<p></p>"]],
+  [p (nil ())] ;
+  
+  "singleton",
+  [[%html "<p>foo</p>"]],
+  [p (pcdata !"foo" @: nil ())] ;
+]
 
 let tests = [
   basics ;
@@ -346,4 +396,5 @@ let tests = [
   antiquot ;
   svg ;
   svg_element_names ;
+  wrapping ;
 ]

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -369,6 +369,10 @@ let wrapping =
   !:[%html "<p>foo</p>"],
   !:(p (pcdata !"foo" @: nil ())) ;
   
+  "wrapped functions",
+  !:[%html "<input method=get />"],
+  !:(input ~a:[a_method !`Get] ())
+
 ]
 
 
@@ -409,6 +413,10 @@ let antiquot =
   "last child",
   [%html "<p></p>" (elt1()) ],
   (p (nil()) @: (elt1()));
+
+  "wrapped functions",
+  !:[%html "<input method="!`Get" />"],
+  !:(input ~a:[a_method !`Get] ())
 
   (* should succeed *)
   (* "escape", *)


### PR DESCRIPTION
I was somehow convinced that this was working already, but apparenty it didn't.
I extended the test cases to cover wrapped APIs and I fixed a few bugs.

After this patch, this works:

```ocaml
open Tyxml_js.R

let%html make title content =
  {|<html>
     <head>
       <title>|}title{|</title>
     </head>
     <body>|}content{|</body>
   </html>
  |}
```


and yields a completely reactive webpage. :heart: 
```ocaml
val make :
  [< Html_types.title_content_fun ] Tyxml_js.To_dom.elt React.signal ->
  [< Html_types.object__content_fun > `PCDATA ] Tyxml_js.To_dom.elt ReactiveData.RList.t ->
  [> Html_types.html ] Tyxml_js.To_dom.elt
```
