### PR TITLE
remove uchar compatability library from build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@ BLD=../_build/default
 SRC=..
 
 PKGS=\
-  -package uchar -package uutf -package re -package markup \
+  -package uutf -package re -package markup \
   -package ppx_tools_versioned
 
 INCS=\

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -7,7 +7,7 @@
   (modules_without_implementation
    (Xml_sigs Html_sigs Svg_sigs Html_types Svg_types))
   (synopsis "Statically correct HTML and SVG documents (Functor version)")
-  (libraries (uchar uutf re))
+  (libraries (uutf re))
   (flags (:standard
           -safe-string))
 ))

--- a/tyxml.opam
+++ b/tyxml.opam
@@ -16,7 +16,6 @@ build: [
 
 depends: [
   "jbuilder" {build}
-  "uchar"
   "uutf" {>= "1.0.0"}
   "re" {>= "1.5.0"}
   "alcotest" {test}


### PR DESCRIPTION
This has been included in the OCaml standard library since
version 4.03.0, which is also the minimum version used by
tyxml.

Removing the compat eliminates a non-dune build dependency,
which in turn makes it easier to embed tyxml as part of a
larger monorepo build using a single dune invocation.

Signed-off-by: Anil Madhavapeddy <anil@recoil.org>