### PR TITLE
Adapt the PPX to upcoming Markup.ml 0.9.0

### DIFF
--- a/ppx/tyxml_ppx.ml
+++ b/ppx/tyxml_ppx.ml
@@ -326,7 +326,7 @@ let markup_to_expr lang loc expr =
       let node = Common.value @@ Element.comment ~loc ~lang s in
       assemble lang (node :: children)
 
-    | Some (`Xml _ | `Doctype _ | `PI _)  ->
+    | Some (`Xml _ | `Doctype _ | `PI _ | `Raw _)  ->
       assemble lang children
   in
 

--- a/tyxml-ppx.opam
+++ b/tyxml-ppx.opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "jbuilder" {build}
   "tyxml"
-  "markup" {>= "0.7.2"}
+  "markup" {>= "0.9.0"}
   "ppx_tools_versioned"
 ]
 available: ocaml-version >= "4.03"


### PR DESCRIPTION
Markup.ml 0.9.0 adds a new signal, `` `Raw of string``. When the HTML and XML *writers* encounter it, they output the string payload verbatim. The *parsers* never generate this signal.

Since the PPX only uses the HTML parser, it is not affected, except that we have to add a case to ignore this signal (which the PPX will never get).


When releasing Markup, I'll update constraints/conflicts on existing TyXML releases.