### PR TITLE
Whitespace in table

### DIFF
--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -908,6 +908,7 @@ module type T = sig
     ?thead: [< | thead] elt wrap ->
     ?tfoot: [< | tfoot] elt wrap ->
     ([< | table_attrib], [< | table_content_fun], [> | table]) star
+  [@@reflect.filter_whitespace]
   [@@reflect.element "table"]
 
   val tablex :
@@ -916,6 +917,7 @@ module type T = sig
     ?thead: [< | thead] elt wrap ->
     ?tfoot: [< | tfoot] elt wrap ->
     ([< | tablex_attrib], [< | tablex_content_fun], [> | tablex]) star
+  [@@reflect.filter_whitespace]
   [@@reflect.element "table" "table"]
 
   val colgroup :

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -920,23 +920,28 @@ module type T = sig
 
   val colgroup :
     ([< | colgroup_attrib], [< | colgroup_content_fun], [> | colgroup]) star
+  [@@reflect.filter_whitespace]
 
   val col : ([< | col_attrib], [> | col]) nullary
 
   val thead :
     ([< | thead_attrib], [< | thead_content_fun], [> | thead]) star
+  [@@reflect.filter_whitespace]
 
   val tbody :
     ([< | tbody_attrib], [< | tbody_content_fun], [> | tbody]) star
+  [@@reflect.filter_whitespace]
 
   val tfoot :
     ([< | tfoot_attrib], [< | tfoot_content_fun], [> | tfoot]) star
+  [@@reflect.filter_whitespace]
 
   val td : ([< | td_attrib], [< | td_content_fun], [> | td]) star
 
   val th : ([< | th_attrib], [< | th_content_fun], [> | th]) star
 
   val tr : ([< | tr_attrib], [< | tr_content_fun], [> | tr]) star
+  [@@reflect.filter_whitespace]
 
   (** {3 Forms} *)
 

--- a/ppx/element_content.ml
+++ b/ppx/element_content.ml
@@ -173,6 +173,8 @@ let table ~lang ~loc ~name children =
   let thead, others = partition (html "thead") others in
   let tfoot, others = partition (html "tfoot") others in
 
+  let others = filter_whitespace others in
+
   let one label = function
     | [] -> []
     | [child] -> [Common.Label.labelled label, Common.wrap_value lang loc child]

--- a/ppx/element_content.ml
+++ b/ppx/element_content.ml
@@ -173,8 +173,6 @@ let table ~lang ~loc ~name children =
   let thead, others = partition (html "thead") others in
   let tfoot, others = partition (html "tfoot") others in
 
-  let others = filter_whitespace others in
-
   let one label = function
     | [] -> []
     | [child] -> [Common.Label.labelled label, Common.wrap_value lang loc child]

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -137,6 +137,45 @@ let basics = "ppx basics", HtmlTests.make Html.[
   [[%html "<ol>   <li>foo</li>  <li>bar</li>   </ol>"]],
   [ol [li [txt "foo"] ; li [txt "bar"]]] ;
 
+  "whitespace in tr",
+  [[%html "<tr>   <td>foo</td>    <td>bar</td>   </tr>"]],
+  [tr [td [txt "foo"] ; td [txt "bar"]]] ;
+
+  "whitespace in table",
+  [[%html "<table>    <tr><td>foo</td></tr>   <tr><td>bar</td></tr>   </table>"]],
+  [table [tr [td [txt "foo"]] ; tr [td [txt "bar"]]]] ;
+
+  "whitespace in table, full example",
+  [[%html "<table>
+  <caption>txt</caption>
+  <colgroup>
+    <col span=\"2\">
+  </colgroup>
+  <thead>
+    <tr>
+      <th>h1</th>
+      <th>h2</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>b1</td>
+      <td>b2</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td>f1</td>
+      <td>f2</td>
+    </tr>
+  </tfoot>
+</table>"]],
+  [table ~caption:(caption [txt "txt"])
+    ~columns:[colgroup [col ~a:[a_span 2] ()]]
+    ~thead:(thead [tr [th [txt "h1"] ; th [txt "h2"]]])
+    ~tfoot:(tfoot [tr [td [txt "f1"] ; td [txt "f2"]]])
+    [tr [td [txt "b1"] ; td [txt "b2"]]]] ;
+
   "whitespace in select",
   [[%html {|<select>  <option value="bar">bar</option>  </select>|}]],
   [select [option ~a:[a_value "bar"] @@ txt "bar"]] ;

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -143,7 +143,7 @@ let basics = "ppx basics", HtmlTests.make Html.[
 
   "whitespace in table",
   [[%html "<table>    <tr><td>foo</td></tr>   <tr><td>bar</td></tr>   </table>"]],
-  [table [tr [td [txt "foo"]] ; tr [td [txt "bar"]]]] ;
+  [tablex [tbody [tr [td [txt "foo"]] ; tr [td [txt "bar"]]]]] ;
 
   "whitespace in table, full example",
   [[%html "<table>
@@ -170,11 +170,11 @@ let basics = "ppx basics", HtmlTests.make Html.[
     </tr>
   </tfoot>
 </table>"]],
-  [table ~caption:(caption [txt "txt"])
+  [tablex ~caption:(caption [txt "txt"])
     ~columns:[colgroup [col ~a:[a_span 2] ()]]
     ~thead:(thead [tr [th [txt "h1"] ; th [txt "h2"]]])
     ~tfoot:(tfoot [tr [td [txt "f1"] ; td [txt "f2"]]])
-    [tr [td [txt "b1"] ; td [txt "b2"]]]] ;
+    [tbody [tr [td [txt "b1"] ; td [txt "b2"]]]]] ;
 
   "whitespace in select",
   [[%html {|<select>  <option value="bar">bar</option>  </select>|}]],


### PR DESCRIPTION
Whitespaces are treated as `PCDATA` which are not accepted in `table` and `tr` elements.

~~I took example on #121 but I suspect this is not the best approach as this problem may occur in a lot of other elements. Would adding some kind of `[@@reflect.filter_whitespace]` in `html_sigs.mli` a better solution ?~~

~~While adding a test, I could not write `[table [tbody [tr [td [txt "foo"]] ; tr [td [txt "bar"]]]]]`. `table` does not accept `tbody`.~~
~~I tried doing the same for `colgroup`, `thead` and `tfoot` elements (see https://github.com/Julow/tyxml/compare/whitespace_in_tr...whitespace_in_table_full) but I had a similar problem.~~

Use the annotation added in https://github.com/ocsigen/tyxml/pull/226