### PR TITLE
Add `[@@reflect.filter whitespace]` annotation

### DIFF
--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -684,11 +684,13 @@ module type T = sig
   val html :
     ?a: ((html_attrib attrib) list) ->
     [< | head] elt wrap -> [< | body] elt wrap -> [> | html] elt
+  [@@reflect.filter_whitespace]
   [@@reflect.element "html"]
 
   val head :
     ?a: ((head_attrib attrib) list) ->
     [< | title] elt wrap -> (head_content_fun elt) list_wrap -> [> | head] elt
+  [@@reflect.filter_whitespace]
   [@@reflect.element "head"]
 
   val base : ([< | base_attrib], [> | base]) nullary
@@ -755,10 +757,10 @@ module type T = sig
   val dl : ([< | dl_attrib], [< | dl_content_fun], [> | dl]) star
 
   val ol : ([< | ol_attrib], [< | ol_content_fun], [> | ol]) star
-  [@@reflect.element "ol"]
+  [@@reflect.filter_whitespace]
 
   val ul : ([< | ul_attrib], [< | ul_content_fun], [> | ul]) star
-  [@@reflect.element "ul"]
+  [@@reflect.filter_whitespace]
 
   val dd : ([< | dd_attrib], [< | dd_content_fun], [> | dd]) star
 
@@ -953,7 +955,7 @@ module type T = sig
 
   val select :
     ([< | select_attrib], [< | select_content_fun], [> | select]) star
-  [@@reflect.element "select"]
+  [@@reflect.filter_whitespace]
 
   val datalist :
     ?children:(

--- a/ppx/element_content.ml
+++ b/ppx/element_content.ml
@@ -108,20 +108,7 @@ let star ~lang ~loc ~name:_ children =
 
 (* Special-cased. *)
 
-let ul ~lang ~loc ~name children =
-  let children = filter_whitespace children in
-  star ~lang ~loc ~name children
-
-let ol ~lang ~loc ~name children =
-  let children = filter_whitespace children in
-  star ~lang ~loc ~name children
-
-let select ~lang ~loc ~name children =
-  let children = filter_whitespace children in
-  star ~lang ~loc ~name children
-
 let head ~lang ~loc ~name children =
-  let children = filter_whitespace children in
   let title, others = partition (html "title") children in
 
   match title with
@@ -248,7 +235,6 @@ let menu ~lang ~loc ~name children =
   children::(nullary ~lang ~loc ~name [])
 
 let html ~lang ~loc ~name children =
-  let children = filter_whitespace children in
   let head, others = partition (html "head") children in
   let body, others = partition (html "body") others in
 

--- a/ppx/element_content.ml
+++ b/ppx/element_content.ml
@@ -64,6 +64,11 @@ let filter_surrounding_whitespace children =
   in
   aux @@ aux children
 
+(** Improve an assembler by first applying [filter_whitespace] on children
+  Used by the [[@@reflect.filter_whitespace]] annotation *)
+let comp_filter_whitespace assembler ~lang ~loc ~name children =
+  assembler ~lang ~loc ~name (filter_whitespace children)
+
 (* Given a parse tree and a string [name], checks whether the parse tree is an
    application of a function with name [name]. *)
 let is_element_with_name name = function

--- a/ppx/element_content.mli
+++ b/ppx/element_content.mli
@@ -77,9 +77,6 @@ val fieldset : assembler
 val datalist : assembler
 val details : assembler
 val menu : assembler
-val ul : assembler
-val ol : assembler
-val select : assembler
 
 (** {1 Misc utilities} *)
 

--- a/ppx/element_content.mli
+++ b/ppx/element_content.mli
@@ -88,3 +88,6 @@ val select : assembler
 val filter_surrounding_whitespace :
   Parsetree.expression Common.value list ->
   Parsetree.expression Common.value list
+
+(** Improve an assembler by removing txt nodes containing only whitespace *)
+val comp_filter_whitespace : assembler -> assembler

--- a/ppx/reflect/reflect.ml
+++ b/ppx/reflect/reflect.ml
@@ -267,7 +267,9 @@ let ocaml_attributes_to_renamed_attribute name attributes =
    [object] in markup).
 
    A val declaration is for an element if it either has a [@@reflect.element]
-   attribute, or its result type is [_ nullary], [_ unary], or [_ star]. *)
+   attribute, or its result type is [_ nullary], [_ unary], or [_ star].
+
+   Also understands the [@@reflect.filter_whitespace] attribute. *)
 let val_item_to_element_info lang value_description =
   let name = value_description.pval_name.txt in
 
@@ -322,6 +324,16 @@ let val_item_to_element_info lang value_description =
       match real_name with
       | None -> []
       | Some real_name -> [real_name, name]
+    in
+
+    let assembler = [ assembler ] in
+
+    let assembler =
+      match
+        find_attr "reflect.filter_whitespace" value_description.pval_attributes
+      with
+      | Some _  -> "comp_filter_whitespace" :: assembler
+      | None    -> assembler
     in
 
     Some (assembler, labeled_attributes, rename)
@@ -424,6 +436,11 @@ module Combi = struct
   let id = AC.evar
   let expr x = x
   let let_ p f (x,e) = Str.value Nonrecursive [Vb.mk (p x) (f e)]
+  let rec compose_ids =
+    function
+    | [ i ]   -> id i
+    | i :: tl -> AC.app (id i) [compose_ids tl]
+    | []      -> assert false
 end
 
 (** Create a module based on the various things collected while reading the file. *)
@@ -442,7 +459,7 @@ let emit_module () =
     open Element_content
 
     let element_assemblers =
-      [%e Combi.(list @@ tuple2 str id) !element_assemblers ]
+      [%e Combi.(list @@ tuple2 str compose_ids) !element_assemblers ]
     let renamed_elements =
       [%e Combi.(list @@ tuple2 str str) !renamed_elements ]
 

--- a/ppx/reflect/reflect.ml
+++ b/ppx/reflect/reflect.ml
@@ -23,10 +23,10 @@
    [html_sigs_reflected.ml]. See comments by functions below and in
    [sigs_reflected.mli] for details. *)
 
+open Ast_helper
 open Ast_mapper
 open Asttypes
 open Parsetree
-open Ast_helper
 module AC = Ast_convenience
 
 


### PR DESCRIPTION
It calls `filter_whitespace` on children just before passing them to the assembler. It avoids the need to write an explicit assembler.

In the 2nd commit I replaced the assembler for `ul`, `ol` and `select` with this annotation and used it on top of `head` and `html`.

I tried to implement it as generic as possible. Adding similar annotations should be very easy.