### PR TITLE
Add `allowfullscreen`, `allowpaymentrequest`, `referrerpolicy` iframe attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
   and removes the ocamlfind library `tyxml.ppx` in favor of `tyxml-ppx`.
   (#197 by Drup, Rudi Grinberg and Anton Bachin)
 * Add simplistic indentation for the Format-based printer (#187 by Drup)
-* Allow the ppx to be used for more exotic tyxml instances, such 
+* Allow the ppx to be used for more exotic tyxml instances, such
   as reactive elements (#200 by Drup)
 * Add `Html.of_seq` and `Svg.of_seq`, which allow to easily import
   HTML parsed with markup in TyXML (#221 by Drup)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # dev
 
-- Allow crossorigin attribute for script element (#243 by Thibault Suzanne)
+## Elements and attributes
+
+* Add allowfullscreen, allowpaymentrequest, referrerpolicy attributes (#242 by Thibault Suzanne)
+* Allow crossorigin attribute for script element (#243 by Thibault Suzanne)
 
 # 4.3.0
 

--- a/lib/html_f.ml
+++ b/lib/html_f.ml
@@ -274,6 +274,12 @@ struct
 
   let a_name = string_attrib "name"
 
+  let a_allowfullscreen =
+    constant_attrib "allowfullscreen"
+
+  let a_allowpaymentrequest =
+    constant_attrib "allowpaymentrequest"
+
   let a_autocomplete x =
     user_attrib C.onoff_of_bool "autocomplete" x
 

--- a/lib/html_f.ml
+++ b/lib/html_f.ml
@@ -280,6 +280,9 @@ struct
   let a_allowpaymentrequest =
     constant_attrib "allowpaymentrequest"
 
+  let a_referrerpolicy x =
+    user_attrib C.string_of_referrerpolicy "referrerpolicy" x
+
   let a_autocomplete x =
     user_attrib C.onoff_of_bool "autocomplete" x
 
@@ -902,6 +905,17 @@ struct
     | `Tty -> "tty"
     | `Tv -> "tv"
     | `Raw_mediadesc s -> s
+
+  let string_of_referrerpolicy = function
+    | `Empty -> ""
+    | `No_referrer -> "no-referrer"
+    | `No_referrer_when_downgrade -> "no-referrer-when-downgrade"
+    | `Origin -> "origin"
+    | `Origin_when_cross_origin -> "origin-when-cross-origin"
+    | `Same_origin -> "same-origin"
+    | `Strict_origin -> "strict-origin"
+    | `Strict_origin_when_cross_origin -> "strict-origin-when-cross-origin"
+    | `Unsafe_url -> "unsafe-url"
 
   let string_of_big_variant = function
     | `Anonymous -> "anonymous"

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -347,6 +347,11 @@ module type T = sig
 
   val a_radiogroup : text wrap -> [> | `Radiogroup] attrib
 
+  val a_referrerpolicy : referrerpolicy wrap -> [> `Referrerpolicy] attrib
+  (** @see
+     <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#Attributes>
+     Iframe HTML documentation. *)
+
   val a_required : unit -> [> | `Required] attrib
 
   val a_reversed : unit -> [> | `Reversed] attrib
@@ -1194,6 +1199,9 @@ module type Wrapped_functions = sig
 
   val string_of_mediadesc :
     ([< Html_types.mediadesc_token] list, string) Xml.W.ft
+
+  val string_of_referrerpolicy :
+    ([< Html_types.referrerpolicy], string) Xml.W.ft
 
   val string_of_numbers : (Html_types.numbers, string) Xml.W.ft
 

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -1061,7 +1061,7 @@ module type T = sig
   [@@ocaml.deprecated "Use txt instead"]
   (** @deprecated Use txt instead *)
 
-  (** {2 Conversion with untyped representation} 
+  (** {2 Conversion with untyped representation}
 
       WARNING: These functions do not ensure HTML or SVG validity! You should
       always explicitly given an appropriate type to the output.

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -256,6 +256,10 @@ module type T = sig
 
   (** {3 Other attributes} *)
 
+  val a_allowfullscreen : unit -> [> | `Allowfullscreen] attrib
+
+  val a_allowpaymentrequest : unit -> [> | `Allowpaymentrequest] attrib
+
   val a_autocomplete : (bool[@onoff]) wrap -> [> | `Autocomplete] attrib
 
   val a_async : unit -> [> | `Async] attrib

--- a/lib/html_types.mli
+++ b/lib/html_types.mli
@@ -1714,6 +1714,7 @@ type iframe_attrib =
     | `Seamless
     | `Width
     | `Height
+    | `Referrerpolicy
   ]
 
 type object__content = [ | flow5 | `Param ]
@@ -2244,6 +2245,18 @@ type link_content_fun = notag
 type link_attrib =
   [ | common | `Hreflang | `Media | `Rel | `Href | `Sizes | `Mime_type
   ]
+
+type referrerpolicy = [
+  | `Empty
+  | `No_referrer
+  | `No_referrer_when_downgrade
+  | `Origin
+  | `Origin_when_cross_origin
+  | `Same_origin
+  | `Strict_origin
+  | `Strict_origin_when_cross_origin
+  | `Unsafe_url
+]
 
 type big_variant =
   [ `W3_org_1999_xhtml

--- a/lib/html_types.mli
+++ b/lib/html_types.mli
@@ -1705,6 +1705,8 @@ type iframe_content_fun = [ | `PCDATA ]
 type iframe_attrib =
   [
     | common
+    | `Allowfullscreen
+    | `Allowpaymentrequest
     | `Src
     | (*| `Srcdoc*)
       `Name

--- a/ppx/attribute_value.ml
+++ b/ppx/attribute_value.ml
@@ -434,6 +434,10 @@ let total_variant (unary, nullary) ?separated_by:_ ?default:_ loc _name s =
   if List.mem variand nullary then Some (Exp.variant ~loc variand None)
   else Some (Exp.variant ~loc unary (Some (Common.string loc s)))
 
+let variant_or_empty empty ?separated_by:_ ?default:_ loc _ s =
+  let variand = variand s in
+  let variand = if variand = "" then empty else variand in
+  Some (Exp.variant ~loc variand None)
 
 
 (* Miscellaneous. *)

--- a/ppx/attribute_value.mli
+++ b/ppx/attribute_value.mli
@@ -180,6 +180,11 @@ val total_variant : (string * string list) -> parser
     Any other string [s] is mapped to the parse trees for
     [`EverythingElse s]. *)
 
+val variant_or_empty : string -> parser
+(** [variant_or_empty empty] is used for parsing arguments whose type
+   is a variant, possibly the empty string. It behaves like [variant]
+   for every string but the empty one, which will be parsed as if it
+   was the [empty] parameter. *)
 
 
 (* {2 Miscellaneous} *)

--- a/ppx/reflect/reflect.ml
+++ b/ppx/reflect/reflect.ml
@@ -192,6 +192,9 @@ let rec to_attribute_parser lang name = function
   | [[%type: linktypes]] ->
     [%expr spaces (total_variant Html_types_reflected.linktype)]
 
+  | [[%type: referrerpolicy]] ->
+    [%expr variant_or_empty "Empty"]
+
   | [[%type: mediadesc]] ->
     [%expr commas (total_variant Html_types_reflected.mediadesc_token)]
 

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -214,6 +214,14 @@ let attribs = "ppx attribs", HtmlTests.make Html.[
   "touch events",
   [[%html "<div ontouchstart='alert()'></div>"]],
   [div ~a:[a_ontouchstart "alert()"] []] ;
+
+  "empty string as referrer policy",
+  [[%html "<iframe referrerpolicy=''></iframe>"]],
+  [iframe ~a:[a_referrerpolicy `Empty] []];
+
+  "dashes in referrer policy",
+  [[%html "<iframe referrerpolicy='no-referrer-when-downgrade'></iframe>"]],
+  [iframe ~a:[a_referrerpolicy `No_referrer_when_downgrade] []];
 ]
 
 let ns_nesting = "namespace nesting" , HtmlTests.make Html.[

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -149,12 +149,12 @@ let basics = "ppx basics", HtmlTests.make Html.[
   [[%html {|<figure> <figcaption> hello </figcaption> <img src="foo.jpg" alt="a" /> </figure>|}]],
   [figure ~figcaption:(`Top (figcaption [txt " hello "]))
      [txt " "; img ~src:"foo.jpg" ~alt:"a" () ; txt " " ]];
-  
+
   "figcaption last",
   [[%html {|<figure> <img src="foo.jpg" alt="a" /> <figcaption> hello </figcaption> </figure>|}]],
   [figure ~figcaption:(`Bottom (figcaption [txt " hello "]))
      [txt " "; img ~src:"foo.jpg" ~alt:"a" () ; txt " " ]];
-  
+
 ]
 
 let attribs = "ppx attribs", HtmlTests.make Html.[
@@ -326,7 +326,7 @@ let svg_element_names = "svg element names", SvgTests.make Svg.[
 
 ]
 
-(* The regular HTML module, but with most type equality hidden. 
+(* The regular HTML module, but with most type equality hidden.
    This forces the use of the wrapping functions provided in Xml.W.
 *)
 module HtmlWrapped : sig
@@ -353,11 +353,11 @@ let (!:) x = x @: nil ()
 let wrapping =
   let module Html = HtmlWrapped in
   "wrapping", HtmlWrappedTests.make Html.[
-    
+
   "elem",
   !:[%html "<p></p>"],
   !:(p (nil ())) ;
-  
+
   "child",
   !:[%html "<p><span></span></p>"],
   !:(p (span (nil ()) @: nil ())) ;
@@ -381,7 +381,7 @@ let wrapping =
   "txt",
   !:[%html "<p>foo</p>"],
   !:(p (txt !"foo" @: nil ())) ;
-  
+
   "wrapped functions",
   !:[%html "<input method=get />"],
   !:(input ~a:[a_method !`Get] ())
@@ -393,10 +393,10 @@ let elt1() = !: HtmlWrapped.(span !: (txt !"one"))
 let elt2() = !: HtmlWrapped.(b !: (txt !"two"))
 let id = !"pata"
 
-let antiquot = 
+let antiquot =
   let module Html = HtmlWrapped in
   "ppx antiquot", HtmlWrappedTests.make Html.[
-  
+
   "child",
   !:[%html "<p>" (elt1()) "</p>"],
   !:(p (elt1()));


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element
https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-referrerpolicy

Note that:
- Referrerpolicy is an enumerated attribute, usually translated as a variant, except is also accepts the empty string as a valid keyword. I added a `variant_or_empty` parser that can parse this kind of attribute, parameterised by the variant to which the empty string will be mapped (given as a string, for instance `"Empty"` for the ``Empty` polyvar).
- Some other elements such as `a` and `area` should accept referrer policies, but the MDN considers this as experimental. Although I did not add this support, this should not be too hard now that the attribute exists.

Thanks @Drup for the help.