### PR TITLE
Allow crossorigin attribute for script element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# dev
+
+- Allow crossorigin attribute for script element (#243 by Thibault Suzanne)
+
 # 4.3.0
 
 * Dunify

--- a/lib/html_types.mli
+++ b/lib/html_types.mli
@@ -2225,7 +2225,7 @@ type style_attrib = [ | common | `Media | `Mime_type | `Scoped ]
 type script = [ | `Script ]
 
 type script_attrib =
-  [ | common | `Async | `Charset | `Src | `Defer | `Mime_type
+  [ | common | `Async | `Charset | `Src | `Defer | `Mime_type | `Crossorigin
   ]
 
 type script_content = [ | `PCDATA ]


### PR DESCRIPTION
https://developer.mozilla.org/fr/docs/Web/HTML/Element/script

`a_crossorigin` happens to already be defined, with an already correct type. This PR merely adds this as an acceptable attribute for `script`.