### PR TITLE
Add data-* attribute to SVG

### DIFF
--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -244,6 +244,8 @@ struct
 
   let a_id = string_attrib "id"
 
+  let a_user_data name = string_attrib ("data-" ^ name)
+
   let a_xml_base = string_attrib "xml:base"
 
   let a_xml_lang = string_attrib "xml:lang"

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -156,6 +156,8 @@ module type T = sig
 
   val a_id : string wrap -> [> | `Id ] attrib
 
+  val a_user_data : string -> string wrap -> [> | `User_data] attrib
+
   val a_xml_base : iri wrap -> [> | `Xml_Base ] attrib
     [@@ocaml.deprecated "Removed in SVG2"]
   (** @deprecated Removed in SVG2 *)

--- a/lib/svg_types.mli
+++ b/lib/svg_types.mli
@@ -119,7 +119,7 @@ type graphics_ref_element = [ | `Image | `Use ]
 type conditional_processing_attr =
   [ | `RequiredExtensions | `RequiredFeatures | `SystemLanguage ]
 
-type core_attr = [ | `Id | `Xml_base | `Xml_lang | `Xml_space ]
+type core_attr = [ | `Id | `Xml_base | `Xml_lang | `Xml_space | `User_data ]
 
 type transfer_attr =
   [

--- a/ppx/reflect/reflect.ml
+++ b/ppx/reflect/reflect.ml
@@ -158,6 +158,7 @@ let rec to_attribute_parser lang name = function
   | [[%type: color]] -> [%expr string]
 
   | [[%type: nmtoken]; [%type: text wrap]] -> [%expr wrap string]
+  | [[%type: string]; [%type: string wrap]] -> [%expr wrap string]
   | [[%type: string]; [%type: string list wrap]] -> [%expr wrap (spaces string)]
 
   | [[%type: Xml.event_handler]]

--- a/test/dune
+++ b/test/dune
@@ -8,6 +8,13 @@
 )
 
 (test
+ (name test_svg)
+ (modules test_svg)
+ (libraries tyxml alcotest)
+ (package tyxml)
+)
+
+(test
  (name test_ppx)
  (modules test_ppx)
  (libraries tyxml alcotest)

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -267,6 +267,11 @@ let svg = "svg", SvgTests.make Svg.[
   [text
     ~a:[a_dx_list [1., None; 2., None]; a_dy_list [3., None; 4., None]] []] ;
 
+  "text data-foo",
+  [[%svg "<text data-foo='valfoo' />"]],
+  [text
+    ~a:[a_user_data "foo" "valfoo"] []] ;
+
   "feColorMatrix type",
   [[%svg "<feColorMatrix type='matrix'/>"]],
   [feColorMatrix ~a:[a_feColorMatrix_type `Matrix] []] ;

--- a/test/test_svg.ml
+++ b/test/test_svg.ml
@@ -1,0 +1,23 @@
+open Tyxml
+
+let to_string = Format.asprintf "%a" (Svg.pp_elt ())
+
+let tyxml_tests l =
+  let f (name, (ty : Svg_types.text Svg.elt), s) =
+    name, `Quick, fun () -> Alcotest.(check string) name (to_string ty) s
+  in
+  List.map f l
+
+let svg_attributes = "svg attributes", tyxml_tests Svg.[
+
+  "text data-foo",
+  text ~a:[ a_user_data "foo" "valfoo" ] [],
+  "<text data-foo=\"valfoo\"></text>" ;
+
+]
+
+let tests = [
+  svg_attributes ;
+]
+
+let () = Alcotest.run "tyxml" tests


### PR DESCRIPTION
Hello,

This is an attempt to add data-* attribute to SVG. At this time, that doesn't work with ppx. Any clue to fix it is welcome!

[https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/data-*](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/data-*)
