### PR TITLE
Preserve homemade elements.

### DIFF
--- a/examples/basic_website_jsx/home_page.re
+++ b/examples/basic_website_jsx/home_page.re
@@ -1,0 +1,11 @@
+open Tyxml;
+
+let createElement = (~title: string, ~children: list('a), ()): Html.doc => {
+  <html>
+    <head>
+      <title> {Html.txt(title)} </title>
+      <link rel="stylesheet" href="home.css" />
+    </head>
+    <body> ...children </body>
+  </html>
+};

--- a/examples/basic_website_jsx/site_html.re
+++ b/examples/basic_website_jsx/site_html.re
@@ -1,6 +1,6 @@
 open Tyxml;
 
-let this_title = Html.txt("Your Cool Web Page");
+let this_title = "Your Cool Web Page";
 
 let image_box = <div id="image_box" />;
 
@@ -34,13 +34,9 @@ let content_box =
 let main_script = <script src="main.js"> "" </script>;
 
 let home_page_doc =
-  <html>
-    <head>
-      <title> this_title </title>
-      <link rel="stylesheet" href="home.css" />
-    </head>
-    <body> image_box content_box main_script </body>
-  </html>;
+  <Home_page title=this_title>
+    image_box content_box main_script
+  </Home_page>;
 
 // The set of pages in your website.
 let pages = [("index.html", home_page_doc)];


### PR DESCRIPTION
Homemade elements are distinguished by paths whose last part starts with an uppercase. Those will be preserved with the following spec:
- `<Foo a=x> children </Foo>` turns into `Foo.createElement ~a:x ~children:children ()`
- `<Foo a=x />` turns into `Foo.createElement ~a:x ()`
  No children at all.

Apparently, this is consistent with revery (cc @wokalski)

The list of children are interpreted according to the usual tyxml JSX rule and will be wrapped. In particular, if the tyxml is reactive, it'll be a reactive list.

@Khady, does that work for you ? :)
The previous version removed the `()` at the end, but keeping only labelled argument is a recipe for trouble, and @wokalski gave a fairly convincing case for removing the `~children` argument when the list is empty.