### PR TITLE
Update allowed inputmodes.

### DIFF
--- a/lib/html_f.ml
+++ b/lib/html_f.ml
@@ -1021,6 +1021,8 @@ struct
     | `Tel -> "tel"
     | `Email -> "email"
     | `Url -> "url"
+    | `Text -> "text"
+    | `Decimal -> "decimal"
     | `Other s -> s
 
   let string_of_input_type = function

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -327,10 +327,9 @@ module type T = sig
   [@@reflect.attribute "min" ["input"]]
 
   val a_inputmode :
-    [< `Verbatim | `Latin | `Latin_name | `Latin_prose | `Full_width_latin
-    | `Kana | `Katakana | `Numeric | `Tel | `Email | `Url ] wrap ->
+    [< `None | `Text | `Decimal | `Numeric | `Tel | `Search | `Email | `Url ] wrap ->
     [> `Inputmode] attrib
-  (** @see <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes> Input HTML documentation. *)
+  (** @see <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode> inputmode documentation. *)
 
   val a_novalidate : unit -> [> | `Novalidate] attrib
 

--- a/lib/html_types.mli
+++ b/lib/html_types.mli
@@ -2369,6 +2369,9 @@ type big_variant =
   | `Tel
   | `Email
   | `Url
+  | `Text
+  | `Decimal
+  | `Search
   ]
 
 type sandbox_token =


### PR DESCRIPTION
Based on https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode.

Fixes #278.