### PR TITLE
Add svg fill-rule attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 * Add support for `type` attribute on `<script>` elements
   (#293 by Ulrik @ulrikstrid Strid and Chas @cemerick Emerick)
 
+* Add svg `fill-rule` attribute
+  (#294 by Eric @dedbox Griffis)
+
 # 4.5.0
 
 * Move all the PPXs to ppxlib

--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -101,6 +101,10 @@ let string_of_paint = function
     (string_of_iri iri) ^" "^ (string_of_paint_whitout_icc b)
   | #paint_whitout_icc as c -> string_of_paint_whitout_icc c
 
+let string_of_fill_rule = function
+  | `Nonzero -> "nonzero"
+  | `Evenodd -> "evenodd"
+
 module Make_with_wrapped_functions
 
     (Xml : Xml_sigs.T)
@@ -534,6 +538,8 @@ struct
 
   let a_animation_fill x =
     user_attrib C.string_of_big_variant "fill" x
+
+  let a_fill_rule = user_attrib C.string_of_fill_rule "fill-rule"
 
   let a_calcMode x =
     user_attrib C.string_of_big_variant "calcMode" x
@@ -1105,6 +1111,8 @@ struct
     | Some __svg -> string_of_angle __svg
 
   let string_of_paint = string_of_paint
+
+  let string_of_fill_rule = string_of_fill_rule
 
   let string_of_strokedasharray = function
     | [] -> "none"

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -488,6 +488,8 @@ module type T = sig
   val a_animation_fill : [< | `Freeze | `Remove ] wrap -> [> | `Fill_Animation ] attrib
     [@@reflect.attribute "fill" ["animation"]]
 
+  val a_fill_rule : fill_rule wrap -> [> | `Fill_rule ] attrib
+
   val a_calcMode :
     [< | `Discrete | `Linear | `Paced | `Spline ] wrap -> [> | `CalcMode ] attrib
 
@@ -1105,6 +1107,8 @@ module type Wrapped_functions = sig
   val string_of_orient : (Svg_types.Unit.angle option, string) Xml.W.ft
 
   val string_of_paint : ([< Svg_types.paint], string) Xml.W.ft
+  
+  val string_of_fill_rule : ([< Svg_types.fill_rule], string) Xml.W.ft
 
   val string_of_strokedasharray : (Svg_types.lengths, string) Xml.W.ft
 

--- a/lib/svg_types.mli
+++ b/lib/svg_types.mli
@@ -288,6 +288,10 @@ type paint =
   [ paint_whitout_icc
   | `Icc of (iri * paint_whitout_icc option) ]
 
+type fill_rule =
+  [ `Nonzero
+  | `Evenodd ]
+
 (* Transformation *)
 type transform =
   [ `Matrix of (float * float * float * float * float * float)

--- a/syntax/attribute_value.ml
+++ b/syntax/attribute_value.ml
@@ -484,6 +484,17 @@ let paint ?separated_by:_ ?default:_ loc name s =
             `Icc ([%e iri], Some [%e paint_without_icc loc name remainder])]
     end [@metaloc loc]
 
+let fill_rule ?separated_by:_ ?default:_ loc _name s =
+  begin match s with
+  | "nonzero" ->
+    Some [%expr `Nonzero]
+  
+  | "evenodd" ->
+    Some [%expr `Evenodd]
+
+  | _ -> None
+  end [@metaloc loc]
+
 let srcset_element =
   let space = Re_str.regexp " +" in
 

--- a/syntax/attribute_value.mli
+++ b/syntax/attribute_value.mli
@@ -198,6 +198,12 @@ val paint : parser
    {:{https://www.w3.org/TR/SVG/painting.html#SpecifyingPaint} Specifying
    paint}. *)
 
+val fill_rule : parser
+(** Parses an SVG fill-rule value.
+
+    @see <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule>
+*)
+
 val srcset_element : parser
 (** Used for [a_srcset]. *)
 

--- a/test/test_jsx.re
+++ b/test/test_jsx.re
@@ -278,6 +278,16 @@ let svg = (
           ),
         ],
       ),
+      (
+        "fill_rule nonzero",
+        [<path fill_rule="nonzero" />],
+        [path(~a=[a_fill_rule(`Nonzero)], [])],
+      ),
+      (
+        "fill_rule evenodd",
+        [<path fill_rule="evenodd" />],
+        [path(~a=[a_fill_rule(`Evenodd)], [])],
+      ),
     ],
   ),
 );

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -370,6 +370,14 @@ let svg = "svg", SvgTests.make Svg.[
   [[%svg "<animation fill='freeze' values='1 2'/>"]],
   [animation ~a:[a_animation_fill `Freeze; a_animation_values ["1"; "2"]] []] ;
 
+  "fill_rule type nonzero",
+  [[%svg "<path fill-rule='nonzero'/>"]],
+  [path ~a:[a_fill_rule `Nonzero] []] ;
+
+  "fill_rule type evenodd",
+  [[%svg "<path fill-rule='evenodd'/>"]],
+  [path ~a:[a_fill_rule `Evenodd] []] ;
+
 ]
 
 let svg_element_names = "svg element names", SvgTests.make Svg.[


### PR DESCRIPTION
Hello!

I noticed that there is a `` `Fill_rule`` constructor in `Svg_types.presentation_attr`, but I could not find an attribute function that uses it. So, this PR adds an `a_fill_rule` attribute function that accepts `` `Nonzero `` or `` `Evenodd ``.

See https://www.w3.org/TR/SVG11/painting.html#FillRuleProperty for details on the fill-rule attribute.

I believe this branch is at least mostly ready for review. Since this is my first contribution, I'm not entirely sure. I have succeeded in using `a_fill_rule` from my local fork in another project, and the existing unit tests are passing, but I have not added any new unit tests.