### PR TITLE
[picture-tag] <img> should be the last child of a <picture> tag

### DIFF
--- a/lib/html_f.ml
+++ b/lib/html_f.ml
@@ -807,7 +807,8 @@ struct
     Xml.leaf ~a "img"
 
   let picture ~img ?a elts =
-    let content = W.cons img elts in
+    let tail_node = W.cons img (W.nil ()) in
+    let content = W.append elts tail_node in
     Xml.node ?a "picture" content
 
   let meta = terminal "meta"

--- a/test/test_html.ml
+++ b/test/test_html.ml
@@ -23,9 +23,9 @@ let html_elements = "html elements", tyxml_tests Html.[
     ]
   ],
   {|<div><picture id="idpicture">|}
-    ^ {|<img src="picture/img.png" alt="test picture/img.png" id="idimg"/>|}
     ^ {|<source type="image/webp" src="picture/img1.webp"/>|}
     ^ {|<source type="image/jpeg" src="picture/img2.jpg"/>|}
+    ^ {|<img src="picture/img.png" alt="test picture/img.png" id="idimg"/>|}
   ^ {|</picture></div>|} ;
 ]
 


### PR DESCRIPTION
According to :  
- [HTML Specs](https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element)
