### PR TITLE
ppx: textarea tag should be allowed to have no child 

### DIFF
--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -1012,6 +1012,7 @@ module type T = sig
 
   val textarea :
     ([< | textarea_attrib], [< | textarea_content_fun], [> | textarea]) unary
+  [@@reflect.element "textarea"]
 
   val keygen : ([< | keygen_attrib], [> | keygen]) nullary
 

--- a/syntax/element_content.ml
+++ b/syntax/element_content.ml
@@ -218,7 +218,7 @@ let datalist ~lang ~loc ~name children =
   children::(nullary ~lang ~loc ~name [])
 
 
-let script ~lang ~loc ~name children =
+let at_most_one_child ~lang ~loc ~name children =
   match children with
   | [] ->
     let child = Common.txt ~loc ~lang "" in
@@ -227,6 +227,11 @@ let script ~lang ~loc ~name children =
     let child = Common.wrap_value lang loc child in
     [Nolabel, child]
   | _ -> Common.error loc "%s can have at most one child" name
+
+let script = at_most_one_child
+
+(* https://html.spec.whatwg.org/#the-textarea-element *)
+let textarea = at_most_one_child
 
 let details ~lang ~loc ~name children =
   let summary, others = partition (html "summary") children in

--- a/syntax/element_content.mli
+++ b/syntax/element_content.mli
@@ -79,6 +79,7 @@ val details : assembler
 val menu : assembler
 val picture : assembler
 val script : assembler
+val textarea : assembler
 
 (** {1 Misc utilities} *)
 

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -211,6 +211,10 @@ let basics = "ppx basics", HtmlTests.make Html.[
   [[%html {|<script type="text/javascript"></script>|}]],
   [script ~a:[a_script_type (`Mime "text/javascript")] @@ txt ""];
 
+  "script empty",
+  [[%html {|<script></script>|}]],
+  [script @@ txt ""];
+
 ]
 
 let attribs = "ppx attribs", HtmlTests.make Html.[

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -215,6 +215,10 @@ let basics = "ppx basics", HtmlTests.make Html.[
   [[%html {|<script></script>|}]],
   [script @@ txt ""];
 
+  "textarea empty",
+  [[%html {|<textarea></textarea>|}]],
+  [textarea @@ txt ""];
+
 ]
 
 let attribs = "ppx attribs", HtmlTests.make Html.[


### PR DESCRIPTION
The solution relies on previous work for empty `<script>` tags.