### PR TITLE
Typo in polymorphic variant `Gradient_Transform`.

### DIFF
--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -275,7 +275,7 @@ module type T = sig
     [< `UserSpaceOnUse | `ObjectBoundingBox ] wrap ->
     [ | `GradientUnits ] attrib
 
-  val a_gradientTransform : transforms wrap -> [> | `Gradient_Transform ] attrib
+  val a_gradientTransform : transforms wrap -> [> | `GradientTransform ] attrib
 
   val a_spreadMethod :
     [< `Pad | `Reflect | `Repeat ] wrap -> [> | `SpreadMethod ] attrib

--- a/test/test_svg.ml
+++ b/test/test_svg.ml
@@ -1,9 +1,8 @@
 open Tyxml
 
-let to_string = Format.asprintf "%a" (Svg.pp_elt ())
-
 let tyxml_tests l =
-  let f (name, (ty : Svg_types.text Svg.elt), s) =
+  let f (name, ty, s) =
+    let to_string = Format.asprintf "%a" (Svg.pp_elt ()) in
     name, `Quick, fun () -> Alcotest.(check string) name (to_string ty) s
   in
   List.map f l
@@ -16,8 +15,26 @@ let svg_attributes = "svg attributes", tyxml_tests Svg.[
 
 ]
 
+let svg_filters = "svg filters", tyxml_tests Svg.[
+
+  "filter gaussian blur",
+  filter ~a:[ a_x (-0.1, None) ; a_y (-0.1, None) ; a_width (0.2, None) ; a_height (0.2, None) ]
+    [ feGaussianBlur ~a:[a_stdDeviation (0.2, None)] [] ],
+  "<filter x=\"-0.1\" y=\"-0.1\" width=\"0.2\" height=\"0.2\"><feGaussianBlur stdDeviation=\"0.2\"></feGaussianBlur></filter>" ;
+
+  "linear gradient",
+  linearGradient ~a:[ a_gradientTransform [`Rotate ((10., None), Some (0.5, 0.5))] ]
+    [
+      stop ~a:[ a_offset (`Percentage 0.) ; a_stop_color "white" ] [] ;
+      stop ~a:[ a_offset (`Percentage 100.) ; a_stop_color "red" ] []
+    ],
+  "<linearGradient gradientTransform=\"rotate(10 0.5 0.5)\"><stop offset=\"0%\" stop-color=\"white\"></stop><stop offset=\"100%\" stop-color=\"red\"></stop></linearGradient>"
+
+]
+
 let tests = [
   svg_attributes ;
+  svg_filters
 ]
 
 let () = Alcotest.run "tyxml-svg" tests


### PR DESCRIPTION
It should fix #313.

I'm surprised that I didn't had to change any implementation, but just the signature. Maybe we should add some tests.