### PR TITLE
Reintroduction of `formmethod`

### DIFF
--- a/lib/html_f.ml
+++ b/lib/html_f.ml
@@ -255,7 +255,7 @@ struct
   let a_method x =
     user_attrib C.string_of_big_variant "method" x
 
-  let a_formmethod = a_method
+  let a_formmethod x = user_attrib C.string_of_big_variant "formmethod" x
 
   let a_enctype = string_attrib "enctype"
 

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -503,9 +503,7 @@ module type T = sig
     [< | `Get | `Post] wrap -> [> | `Method] attrib
 
   val a_formmethod :
-    [< | `Get | `Post] wrap -> [> | `Method] attrib
-  [@@ocaml.deprecated "Use a_method"]
-  (** @deprecated Use a_method *)
+    [< | `Get | `Post] wrap -> [> | `Formmethod] attrib
 
   val a_multiple : unit -> [> | `Multiple] attrib
 

--- a/lib/html_types.mli
+++ b/lib/html_types.mli
@@ -2050,7 +2050,7 @@ type input_attrib =
     | `Checked
     | `Disabled
     | `Form
-    | `Formation
+    | `Formaction
     | `Formenctype
     | `Method
     | `Formnovalidate

--- a/lib/html_types.mli
+++ b/lib/html_types.mli
@@ -2052,6 +2052,7 @@ type input_attrib =
     | `Form
     | `Formaction
     | `Formenctype
+    | `Formmethod
     | `Method
     | `Formnovalidate
     | `Formtarget
@@ -2114,6 +2115,7 @@ type button_attrib =
     | `Form
     | `Formaction
     | `Formenctype
+    | `Formmethod
     | `Method
     | `Formnovalidate
     | `Formtarget

--- a/test/test_html.ml
+++ b/test/test_html.ml
@@ -11,8 +11,8 @@ let html_elements = "html elements", tyxml_tests Html.[
   "<div><a></a></div>" ;
 
   "input",
-  input ~a:[a_formaction "post.html"] (),
-  "<input formaction=\"post.html\"/>";
+  input ~a:[a_formaction "post.html"; a_formmethod `Post] (),
+  "<input formaction=\"post.html\" formmethod=\"POST\"/>";
 
   "a",
   canvas [a []],

--- a/test/test_html.ml
+++ b/test/test_html.ml
@@ -10,6 +10,10 @@ let html_elements = "html elements", tyxml_tests Html.[
   div [a []],
   "<div><a></a></div>" ;
 
+  "input",
+  input ~a:[a_formaction "post.html"] (),
+  "<input formaction=\"post.html\"/>";
+
   "a",
   canvas [a []],
   "<canvas><a></a></canvas>";


### PR DESCRIPTION
- First commit: corrects a subtle typo `Formation` -> `Formaction` in the `input_attrib`.
- Second commit: Even though `formmethod` is deprecated, the W3C specification of `<input>` does not accept a `method` attribute but rather `formmethod`

https://www.w3.org/TR/2011/WD-html5-20110525/the-input-element.html

I've kept the `method` attribute for `button` and `input` for backwards compatibility, but in an ideal world it would be removed.