### PR TITLE
Adding support for `fill-opacity`

### DIFF
--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -368,7 +368,7 @@ struct
   let a_fy = user_attrib string_of_coord "fy"
 
   let a_offset x =
-    user_attrib C.string_of_offset "offset" x
+    user_attrib C.string_of_number_or_percentage "offset" x
 
   let a_patternUnits x =
     user_attrib C.string_of_big_variant "patternUnits" x
@@ -538,6 +538,8 @@ struct
 
   let a_animation_fill x =
     user_attrib C.string_of_big_variant "fill" x
+
+  let a_fill_opacity = user_attrib C.string_of_number_or_percentage "fill-opacity"
 
   let a_fill_rule = user_attrib C.string_of_fill_rule "fill-rule"
 
@@ -1104,7 +1106,7 @@ struct
 
   let string_of_numbers_semicolon = list ~sep:"; " string_of_number
 
-  let string_of_offset = function
+  let string_of_number_or_percentage = function
     | `Number x -> string_of_number x
     | `Percentage x -> string_of_percentage x
 

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -488,6 +488,10 @@ module type T = sig
   val a_animation_fill : [< | `Freeze | `Remove ] wrap -> [> | `Fill_Animation ] attrib
     [@@reflect.attribute "fill" ["animate"]]
 
+  val a_fill_opacity :
+    [< `Number of number | `Percentage of percentage ] wrap ->
+    [> | `Fill_opacity ] attrib
+
   val a_fill_rule : fill_rule wrap -> [> | `Fill_rule ] attrib
 
   val a_calcMode :

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -1111,7 +1111,8 @@ module type Wrapped_functions = sig
 
   val string_of_numbers_semicolon : (float list, string) Xml.W.ft
 
-  val string_of_offset : ([< Svg_types.offset], string) Xml.W.ft
+  val string_of_number_or_percentage :
+    ([< `Number of number | `Percentage of percentage ], string) Xml.W.ft
 
   val string_of_orient : (Svg_types.Unit.angle option, string) Xml.W.ft
 

--- a/test/test_ppx.ml
+++ b/test/test_ppx.ml
@@ -416,6 +416,10 @@ let svg = "svg", SvgTests.make Svg.[
   [[%svg "<animate fill='freeze' values='1 2'/>"]],
   [animate ~a:[a_animation_fill `Freeze; a_animation_values ["1"; "2"]] []] ;
 
+  "fill_opacity, circle",
+  [[%svg "<circle cx=50 cy=50 r=50 fill-opacity=0.5 />"]],
+  [rect ~a:[a_cx (50., None); a_cy (50., None); a_r (50., None); a_fill_opacity (`Number 0.5)] []] ;
+
   "fill_rule type nonzero",
   [[%svg "<path fill-rule='nonzero'/>"]],
   [path ~a:[a_fill_rule `Nonzero] []] ;


### PR DESCRIPTION
I was in need of the `fill-opacity` attribute, so I did these changes. I haven't changed the parser yet, but I'm not sure where to start.

The attribute `fill-opacity` takes the same kind of argument than `offset` (a number or a percentage), but they mean different things: I think that it would not make sense to reuse the type `offset` (being either a number or a percentage), so I introduced a `number_or_percentage` type. Maybe we should instead declare several types for `offset` and `fill_opacity`?