### PR TITLE
Adding support for the clip-path presentation attribute.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# NEXT
+
+* Add support for the clip-path presentation attribute
+	(#333 by Martin @MBodin Bodin)
+
 # 4.6.0
 
 * Update for OCaml 5.0 and drop support for OCaml 4.2.0

--- a/lib/svg_f.ml
+++ b/lib/svg_f.ml
@@ -379,6 +379,9 @@ struct
   let a_patternTransform x =
     user_attrib C.string_of_transforms "patternTransform" x
 
+  let a_clip_path =
+    string_attrib "clip-path"
+
   let a_clipPathUnits x =
     user_attrib C.string_of_big_variant "clipPathUnits" x
 

--- a/lib/svg_sigs.mli
+++ b/lib/svg_sigs.mli
@@ -298,6 +298,8 @@ module type T = sig
 
   val a_patternTransform : transforms wrap -> [> | `PatternTransform ] attrib
 
+  val a_clip_path : iri wrap -> [> | `Clip_Path ] attrib
+
   val a_clipPathUnits :
     [< `UserSpaceOnUse | `ObjectBoundingBox ] wrap ->
     [> | `ClipPathUnits ] attrib

--- a/test/test_svg.ml
+++ b/test/test_svg.ml
@@ -36,7 +36,7 @@ let svg_clip_path = "svg clip-path", tyxml_tests Svg.[
 
   "use with clip-path",
   use ~a:[ a_clip_path "url(#test-clip)"; a_href "#test-object"] [],
-  {|<use clip-path = "url(#test-clip)" href = "#test-object" />|}
+  {|<use clip-path="url(#test-clip)" href="#test-object"></use>|}
 
 ]
 

--- a/test/test_svg.ml
+++ b/test/test_svg.ml
@@ -32,9 +32,18 @@ let svg_filters = "svg filters", tyxml_tests Svg.[
 
 ]
 
+let svg_clip_path = "svg clip-path", tyxml_tests Svg.[
+
+  "use with clip-path",
+  use ~a:[ a_clip_path "url(#test-clip)"; a_href "#test-object"] [],
+  {|<use clip-path = "url(#test-clip)" href = "#test-object" />|}
+
+]
+
 let tests = [
   svg_attributes ;
-  svg_filters
+  svg_filters ;
+  svg_clip_path
 ]
 
 let () = Alcotest.run "tyxml-svg" tests


### PR DESCRIPTION
I was in need of this attribute.

Note that `clip-path` SVG presentation attribute is different from the `clipPath` SVG tag, which is already supported by TyXML.