### PR TITLE
Prepare for 5.2 AST bump

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -21,9 +21,7 @@ jobs:
           - 4
         include:
           - os: ubuntu-latest
-            ocaml-compiler: "4.04"
-          - os: ubuntu-latest
-            ocaml-compiler: "4.04"
+            ocaml-compiler: "4.08"
 
     runs-on: ${{ matrix.os }}
 

--- a/dune-project
+++ b/dune-project
@@ -25,7 +25,7 @@ It works with textual trees, virtual DOM trees, or any TyXML module.
   (ocaml (>= 4.04))
   (tyxml (= :version))
   (tyxml-syntax (= :version))
-  (ppxlib (>= 0.18))
+  (ppxlib (>= 0.36))
   (alcotest :with-test)
   (reason :with-test)))
 
@@ -46,7 +46,7 @@ It works with textual trees, virtual DOM trees, or any TyXML module.
   (tyxml (= :version))
   (tyxml-syntax (= :version))
   (markup (>= 0.7.2))
-  (ppxlib (>= 0.18))
+  (ppxlib (>= 0.36))
   (re (>= 1.5.0))
   (alcotest :with-test)))
 
@@ -55,7 +55,7 @@ It works with textual trees, virtual DOM trees, or any TyXML module.
  (synopsis "Common layer for the JSX and PPX syntaxes for Tyxml")
  (depends
   (ocaml (>= 4.03))
-  (ppxlib (>= 0.18))
+  (ppxlib (>= 0.36))
   (re (>= 1.5.0))
   (uutf (>= 1.0.0))
   (alcotest :with-test)))

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@ The TyXML JSX allow to write TyXML documents with reason's JSX syntax.
 It works with textual trees, virtual DOM trees, or any TyXML module.
 ")
  (depends
-  (ocaml (>= 4.04))
+  (ocaml (>= 4.08))
   (tyxml (= :version))
   (tyxml-syntax (= :version))
   (ppxlib (>= 0.36))
@@ -42,7 +42,7 @@ The TyXML PPX allow to write TyXML documents using the traditional HTML syntax.
 It works with textual trees, virtual DOM trees, or any TyXML module.
 ")
  (depends
-  (ocaml (>= 4.04))
+  (ocaml (>= 4.08))
   (tyxml (= :version))
   (tyxml-syntax (= :version))
   (markup (>= 0.7.2))
@@ -54,7 +54,7 @@ It works with textual trees, virtual DOM trees, or any TyXML module.
  (name tyxml-syntax)
  (synopsis "Common layer for the JSX and PPX syntaxes for Tyxml")
  (depends
-  (ocaml (>= 4.03))
+  (ocaml (>= 4.08))
   (ppxlib (>= 0.36))
   (re (>= 1.5.0))
   (uutf (>= 1.0.0))
@@ -65,7 +65,7 @@ It works with textual trees, virtual DOM trees, or any TyXML module.
  (synopsis "A library for building correct HTML and SVG documents")
  (description "TyXML provides a set of convenient combinators that uses the OCaml type system to ensure the validity of the generated documents. TyXML can be used with any representation of HTML and SVG: the textual one, provided directly by this package, or DOM trees (`js_of_ocaml-tyxml`) virtual DOM (`virtual-dom`) and reactive or replicated trees (`eliom`). You can also create your own representation and use it to instantiate a new set of combinators.")
  (depends
-  (ocaml (>= 4.03))
+  (ocaml (>= 4.08))
   (re (>= 1.5.0))
   (uutf (>= 1.0.0))
   seq

--- a/ppx/tyxml_ppx.ml
+++ b/ppx/tyxml_ppx.ml
@@ -378,12 +378,12 @@ let markup_cases ~lang ~modname cases =
 let rec markup_function ~lang ~modname e =
   let loc = e.pexp_loc in
   match e.pexp_desc with
-  | Pexp_fun (label,def,pat,content) ->
+  | Pexp_function (params, constraint_, (Pfunction_body content)) ->
     let content = markup_function ~lang ~modname content in
-    {e with pexp_desc = Pexp_fun (label,def,pat,content)}
-  | Pexp_function cases ->
+    {e with pexp_desc = Pexp_function (params, constraint_, (Pfunction_body content))}
+  | Pexp_function (params, constraint_, (Pfunction_cases (cases, loc, attr))) ->
     let cases = markup_cases ~lang ~modname cases in
-    {e with pexp_desc = Pexp_function cases}
+    {e with pexp_desc = Pexp_function (params, constraint_, (Pfunction_cases (cases, loc, attr)))}
   | _ ->
     markup_to_expr_with_implementation lang modname loc @@
     application_to_list e

--- a/tyxml-jsx.opam
+++ b/tyxml-jsx.opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml" {>= "4.04"}
   "tyxml" {= version}
   "tyxml-syntax" {= version}
-  "ppxlib" {>= "0.18"}
+  "ppxlib" {>= "0.36"}
   "alcotest" {with-test}
   "reason" {with-test}
   "odoc" {with-doc}

--- a/tyxml-jsx.opam
+++ b/tyxml-jsx.opam
@@ -18,7 +18,7 @@ doc: "https://ocsigen.org/tyxml/latest/manual/intro"
 bug-reports: "https://github.com/ocsigen/tyxml/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.04"}
+  "ocaml" {>= "4.08"}
   "tyxml" {= version}
   "tyxml-syntax" {= version}
   "ppxlib" {>= "0.36"}

--- a/tyxml-ppx.opam
+++ b/tyxml-ppx.opam
@@ -22,7 +22,7 @@ depends: [
   "tyxml" {= version}
   "tyxml-syntax" {= version}
   "markup" {>= "0.7.2"}
-  "ppxlib" {>= "0.18"}
+  "ppxlib" {>= "0.36"}
   "re" {>= "1.5.0"}
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/tyxml-ppx.opam
+++ b/tyxml-ppx.opam
@@ -18,7 +18,7 @@ doc: "https://ocsigen.org/tyxml/latest/manual/intro"
 bug-reports: "https://github.com/ocsigen/tyxml/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.04"}
+  "ocaml" {>= "4.08"}
   "tyxml" {= version}
   "tyxml-syntax" {= version}
   "markup" {>= "0.7.2"}

--- a/tyxml-syntax.opam
+++ b/tyxml-syntax.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocsigen/tyxml/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.03"}
-  "ppxlib" {>= "0.18"}
+  "ppxlib" {>= "0.36"}
   "re" {>= "1.5.0"}
   "uutf" {>= "1.0.0"}
   "alcotest" {with-test}

--- a/tyxml-syntax.opam
+++ b/tyxml-syntax.opam
@@ -9,7 +9,7 @@ doc: "https://ocsigen.org/tyxml/latest/manual/intro"
 bug-reports: "https://github.com/ocsigen/tyxml/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.36"}
   "re" {>= "1.5.0"}
   "uutf" {>= "1.0.0"}

--- a/tyxml.opam
+++ b/tyxml.opam
@@ -11,7 +11,7 @@ doc: "https://ocsigen.org/tyxml/latest/manual/intro"
 bug-reports: "https://github.com/ocsigen/tyxml/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.08"}
   "re" {>= "1.5.0"}
   "uutf" {>= "1.0.0"}
   "seq"


### PR DESCRIPTION
This PR is a patch for an upcoming release of ppxlib where the internal AST is [bumped from 4.14 to 5.2](https://github.com/ocaml-ppx/ppxlib/pull/514). Until that is merged and released, there is no reason to merge this PR.

To test these changes, you can use the following opam-based workflow. I've made releases of most of these patches to an opam-repository overlay.

```shell
opam switch create ppxlib-bump --repos=ppxlib=git+https://github.com/patricoferris/opam-repository#5.2-ast-bump
opam install <your-package>
```

The following describes the most notable changes to the AST.

Note: no update has been made of the `opam` file, but `ppxlib` will likely need a lower-bound before merging/releasing.

### Functions
---

#### Currently 

In the parsetree currently, functions like:

```ocaml
fun x y z -> ...
```

Are represented roughly as

```ocaml
Pexp_fun(x, Pexp_fun (y, Pexp_fun(z, ...)))
```

Functions like:

```ocaml
function A -> ... | B -> ...
```

Are represented roughly as

```ocaml
Pexp_function ([ case A; case B ])
```

#### Since 5.2

All of these functions now map to a single AST node `Pexp_function` (note, this is the same name as the old cases function). The first argument is a list of parameters meaning:

```ocaml
fun x y z -> ...
```

Now looks like:

```ocaml
Pexp_function([x; y; z], _constraint, body)
```

And the `body` is where we can either have _more_ expressions (`Pfunction_body _`) or cases (`Pfunction_cases _`). That means:

```ocaml
function A -> ... | B -> ...
```

Has an empty list of parameters:

```ocaml
Pexp_function([], _, Pfunction_cases ([case A; case B]))
```

### Local Module Opens for Types

Another feature added in 5.2 was the ability to locally open modules in type definitions. 

```ocaml
module M = struct
  type t = A | B | C
end

type t = Local_open_coming of M.(t)
```

This has a `Ptyp_open (module_identifier, core_type)` AST node. Just like normal module opens this does create some syntactic ambiguity about where things come from inside the parentheses.