### PR TITLE
Add `name` and `ontoggle` attributes for `details` HTML elements.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 * Add support for the clip-path presentation attribute
 	(#333 by Martin @MBodin Bodin)
 
+* Add support for the `name` attribute and `toggle` event on
+  `<details>` elements
+  (#341 by @SylvainBoilard)
+
 # 4.6.0
 
 * Update for OCaml 5.0 and drop support for OCaml 4.2.0

--- a/lib/html_f.ml
+++ b/lib/html_f.ml
@@ -151,6 +151,7 @@ struct
   let a_onsubmit = Xml.event_handler_attrib "onsubmit"
   let a_onsuspend = Xml.event_handler_attrib "onsuspend"
   let a_ontimeupdate = Xml.event_handler_attrib "ontimeupdate"
+  let a_ontoggle = Xml.event_handler_attrib "ontoggle"
   let a_onundo = Xml.event_handler_attrib "onundo"
   let a_onunload = Xml.event_handler_attrib "onunload"
   let a_onvolumechange = Xml.event_handler_attrib "onvolumechange"

--- a/lib/html_sigs.mli
+++ b/lib/html_sigs.mli
@@ -215,6 +215,7 @@ module type T = sig
   val a_onsubmit : Xml.event_handler -> [> | `OnSubmit] attrib
   val a_onsuspend : Xml.event_handler -> [> | `OnSuspend] attrib
   val a_ontimeupdate : Xml.event_handler -> [> | `OnTimeUpdate] attrib
+  val a_ontoggle : Xml.event_handler -> [> | `OnToggle] attrib
   val a_onundo : Xml.event_handler -> [> | `OnUndo] attrib
   val a_onunload : Xml.event_handler -> [> | `OnUnload] attrib
   val a_onvolumechange : Xml.event_handler -> [> | `OnVolumeChange] attrib

--- a/lib/html_types.mli
+++ b/lib/html_types.mli
@@ -2233,7 +2233,7 @@ type details_content = [ | flow5 ]
 
 type details_content_fun = [ | flow5 ]
 
-type details_attrib = [ | common | `Open ]
+type details_attrib = [ | common | `Open | `Name | `OnToggle ]
 
 (* NAME: summary, KIND: star, TYPE: [= common ],[= phrasing ], [=`Summary], ARG: [= phrasing ], ATTRIB:  OUT: [=`Summary] *)
 type summary = [ | `Summary ]


### PR DESCRIPTION
Hello,

This PR adds support for the `name` attribute and specifying a `toggle` event handler for a `details` element.

See:
- https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element ;
- https://html.spec.whatwg.org/multipage/indices.html#event-toggle ;
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#attributes ;
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#events .

Cheers,
