### PR TITLE
doc: make the introduction the package index.mld (for ocaml.org)

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -10,10 +10,10 @@
 (title TyXML)
 (pub /tyxml)
 (profile release)                   ; dev profile treats warning 67 as an error
-(landing tyxml/intro.html)          ; the manual's Introduction is the entry point
+(landing tyxml/index.html)          ; the package home page (docs/index.mld)
 (nav
   (section "TyXML - Manual"
-    (link "Introduction"          tyxml/intro.html    intro)
+    (link "Introduction"          tyxml/index.html    index)
     (link "Functorial interface"  tyxml/functors.html functors)
     (link "Ppx syntax extension"  tyxml/ppx.html      ppx)
     (link "JSX syntax"            tyxml/jsx.html      jsx))

--- a/docs/index.mld
+++ b/docs/index.mld
@@ -1,3 +1,5 @@
+@children_order functors ppx jsx api
+
 {0 TyXML}
 
 Tyxml is a library for building statically correct HTML and SVG documents.


### PR DESCRIPTION
Part of an effort to make the Ocsigen documentation complete and well-formed on ocaml.org (picked up at the next release).

On ocaml.org the documentation landing page of a package (`/p/tyxml/latest/doc/`) is rendered from the package's `index.mld`. TyXML had none (the manual pages are `intro`, `functors`, `ppx`, `jsx`, `api`), so odoc generated a bare module listing instead of a real home page, and the manual pages had no logical order in the sidebar.

## Change

- Rename `docs/intro.mld` to `docs/index.mld`: the introduction already is the manual entry point, so it becomes the package home page.
- Add `@children_order functors ppx jsx api` so the sidebar follows a logical reading order.
- Update the ocsigen.org landing/nav (`doc/wodoc`) to point at `index.html`.

Note: the deployed page URL changes from `/tyxml/latest/tyxml/intro.html` to `…/index.html`. The only internal links to it are in the tutorial (`tuto`), updated in a separate PR.

## Verification

`dune build --profile release @doc` (odoc 3.2.1): the home page is generated from the former introduction and all internal `{!page-…}` references resolve. (Pre-existing cross-package `Js_of_ocaml_tyxml` warnings are unchanged, unrelated to this PR.)