### PR TITLE
doc: update doc/wodoc for wodoc's new defaults

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -8,7 +8,8 @@
 ;; the API together under the tyxml/ package dir.
 (project tyxml)
 (title TyXML)
-(pub /tyxml)
+(url-prefix /tyxml)
+(css /css/style.css /css/ocsigen-odoc.css)  ; shared Ocsigen theme (wodoc css default changed)
 (profile release)                   ; dev profile treats warning 67 as an error
 (landing tyxml/index.html)          ; the package home page (docs/index.mld)
 (nav


### PR DESCRIPTION
wodoc master now ships a built-in default theme and renames the `pub` stanza to `url-prefix` (see ocsigen/wodoc). This keeps tyxml's doc on the shared Ocsigen theme and adopts the new name:

- add `(css /css/style.css /css/ocsigen-odoc.css)` (wodoc's css default changed to a self-contained built-in theme, so this is now needed to keep the shared `/css/` look);
- rename `(pub …)` → `(url-prefix …)`.

The doc CI tracks wodoc master, so no CI change is needed.