### PR TITLE
doc: link Eliom with an odoc reference instead of a hardcoded URL

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -19,3 +19,9 @@
     (link "JSX syntax"            tyxml/jsx.html      jsx))
   (section "TyXML - API"
     (link "API reference" tyxml/api.html api)))
+
+;; Sibling Ocsigen projects this doc links to, so wodoc rewrites their
+;; ocaml.org cross-references to relative links into their deployed docs.
+;; (pkg deploy-dir layout wrapper-module)
+(hosted
+  (eliom eliom true Eliom))

--- a/docs/index.mld
+++ b/docs/index.mld
@@ -18,7 +18,7 @@ To use TyXML in standalone manner, simply install the [tyxml] OPAM package, link
 {2 Use with another library}
 
 TyXML combinators can be used in conjunction with other libraries. Please consult the relevant document. For example,
-{{:https://ocsigen.org/eliom/latest/clientserver-html.html}Eliom}
+{{!/eliom/page-clientserver-html}Eliom}
 and
 {{!Js_of_ocaml_tyxml.Tyxml_js}Js_of_ocaml}.
 
@@ -128,7 +128,7 @@ let mypage =
     (body [mycontent])
 ]}
 
-If you are using {{:https://ocsigen.org/eliom/latest/clientserver-html.html}Eliom}
+If you are using {{!/eliom/page-clientserver-html}Eliom}
 or {{!Js_of_ocaml_tyxml.Tyxml_js}Js_of_ocaml},
 this is the end of TyXML's territory. However, for standalone use, we now need to print our document as an HTML file. The standalone implementation comes with a printer, {!Tyxml.Html.pp}, that we can use to print files:
 


### PR DESCRIPTION
Cross-project-links effort. The TyXML home page linked to Eliom's client/server HTML manual with a hardcoded `https://ocsigen.org/eliom/latest/clientserver-html.html` URL (×2), which always sends the reader to ocsigen.org. Use the odoc cross-package reference `{{!/eliom/page-clientserver-html}}`: odoc resolves it to `/p/eliom` on ocaml.org and wodoc rewrites it to Eliom's deployed docs on ocsigen.org via a new `(hosted (eliom eliom true Eliom))` entry. Compiles with `odoc compile`.