### PR TITLE
doc: list the full Ocsigen family in the hosted table

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -21,8 +21,16 @@
   (section "TyXML - API"
     (link "API reference" tyxml/api.html api)))
 
-;; Sibling Ocsigen projects this doc links to, so wodoc rewrites their
-;; ocaml.org cross-references to relative links into their deployed docs.
-;; (pkg deploy-dir layout wrapper-module)
+;; Sibling Ocsigen projects, so wodoc rewrites their ocaml.org cross-references
+;; to relative links into their deployed docs on ocsigen.org. The full family is
+;; listed (not only the ones this doc currently links to) so that adding a link
+;; later never silently breaks. (pkg deploy-dir layout wrapper-module)
 (hosted
-  (eliom eliom true Eliom))
+  (eliom           eliom           true  Eliom)
+  (ocsigen-toolkit ocsigen-toolkit true  Ot)
+  (ocsigen-start   ocsigen-start   true  Os)
+  (ocsigenserver   ocsigenserver   false Ocsigen)
+  (js_of_ocaml     js_of_ocaml     subdir)
+  (tyxml           tyxml           subdir)
+  (lwt             lwt             subdir)
+  (reactiveData    reactiveData    root))


### PR DESCRIPTION
The `(hosted …)` table now lists the **whole** Ocsigen family (eliom, toolkit, start, ocsigenserver, js_of_ocaml, tyxml, lwt, reactiveData), not only the projects this doc currently links to. This way, adding a cross-project link later is automatically rewritten for ocsigen.org instead of silently staying an unresolved reference. Same canonical table as eliom/toolkit/start.