### PR TITLE
doc: quote hyphenated page names in cross-project references

### DIFF
--- a/docs/index.mld
+++ b/docs/index.mld
@@ -18,7 +18,7 @@ To use TyXML in standalone manner, simply install the [tyxml] OPAM package, link
 {2 Use with another library}
 
 TyXML combinators can be used in conjunction with other libraries. Please consult the relevant document. For example,
-{{!/eliom/page-clientserver-html}Eliom}
+{{!/eliom/page-"clientserver-html"}Eliom}
 and
 {{!Js_of_ocaml_tyxml.Tyxml_js}Js_of_ocaml}.
 
@@ -128,7 +128,7 @@ let mypage =
     (body [mycontent])
 ]}
 
-If you are using {{!/eliom/page-clientserver-html}Eliom}
+If you are using {{!/eliom/page-"clientserver-html"}Eliom}
 or {{!Js_of_ocaml_tyxml.Tyxml_js}Js_of_ocaml},
 this is the end of TyXML's territory. However, for standalone use, we now need to print our document as an HTML file. The standalone implementation comes with a printer, {!Tyxml.Html.pp}, that we can use to print files:
 


### PR DESCRIPTION
odoc cannot parse a **hyphenated** page name in a path reference: `{{!/eliom/page-mobile-apps}}` produces "Unknown reference qualifier" and renders as plain text (no link). It must be quoted: `{{!/eliom/page-"mobile-apps"}}`. This quotes the hyphenated cross-project page references introduced earlier (they were silently broken). Verified: pages now compile with no reference-qualifier error.