### PR TITLE
Fix unused functor parameter warnings breaking the CI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # NEXT
 
+* Fix the development-profile build with recent compilers: anonymize
+  unused functor parameters in printer and functor signatures
+  (warning 67)
 * Fix typo `whitout` in type definition
 	(#324 by Martin @MBodin Bodin)
 * Add support for the clip-path presentation attribute

--- a/lib/html_f.mli
+++ b/lib/html_f.mli
@@ -46,7 +46,7 @@ module Wrapped_functions
 (** Similar to {!Make} but with a custom set of wrapped functions. *)
 module Make_with_wrapped_functions
     (Xml : Xml_sigs.T)
-    (C : Html_sigs.Wrapped_functions with module Xml = Xml)
+    (_ : Html_sigs.Wrapped_functions with module Xml = Xml)
     (Svg : Svg_sigs.T with module Xml := Xml)
   : Html_sigs.Make(Xml)(Svg).T
     with type +'a elt = Xml.elt

--- a/lib/svg_f.mli
+++ b/lib/svg_f.mli
@@ -99,7 +99,7 @@ module Wrapped_functions
 (** Similar to {!Make} but with a custom set of wrapped functions. *)
 module Make_with_wrapped_functions
     (Xml : Xml_sigs.T)
-    (C : Svg_sigs.Wrapped_functions with module Xml = Xml)
+    (_ : Svg_sigs.Wrapped_functions with module Xml = Xml)
   : Svg_sigs.Make(Xml).T
     with type +'a elt = Xml.elt
      and type +'a attrib = Xml.attrib

--- a/lib/xml_print.mli
+++ b/lib/xml_print.mli
@@ -103,7 +103,7 @@ module type TagList = sig val emptytags : string list end
 (** Printers for raw XML modules. *)
 module Make_fmt
     (Xml : Xml_sigs.Iterable)
-    (I : TagList)
+    (_ : TagList)
   : Xml_sigs.Pp with type elt := Xml.elt
 
 (** {2 Deprecated functors}
@@ -113,7 +113,7 @@ module Make_fmt
 
 module Make
     (Xml : Xml_sigs.Iterable)
-    (I : TagList)
+    (_ : TagList)
     (O : Xml_sigs.Output)
   : Xml_sigs.Printer with type out := O.out and type xml_elt := Xml.elt
     [@@ocaml.deprecated "Use Xml_print.Make_fmt instead."]
@@ -129,7 +129,7 @@ module Make_typed
 
 module Make_simple
     (Xml : Xml_sigs.Iterable)
-    (I : TagList)
+    (_ : TagList)
   : Xml_sigs.Simple_printer with type xml_elt := Xml.elt
     [@@ocaml.deprecated "Use Xml_print.Make_fmt instead."]
 


### PR DESCRIPTION
The CI has been red on master since at least #364: recent compilers in the dune development profile treat warning 67 (unused functor parameter) as an error, which breaks `make build` on every platform (see for instance https://github.com/ocsigen/tyxml/actions/runs/29224082355).

The affected parameters (`TagList` in the `Xml_print` functors, `Wrapped_functions` in `Html_f`/`Svg_f.Make_with_wrapped_functions`) only influence behavior, not the result signatures, so they can be anonymous in the interfaces.

With this change, `dune build @install` and `dune runtest` pass in the default profile on OCaml 5.4.

Note: the `(ubuntu-latest, 4.08)` job fails for an unrelated reason (the opam switch initialisation itself fails to solve `ocaml-base-compiler` for 4.08 with opam 2.5.2); this PR does not address that.